### PR TITLE
Support for inner interfaces to jackson module

### DIFF
--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
@@ -19,7 +19,8 @@ class AutoMatterResolver extends AbstractTypeResolver {
 
   @Override
   public JavaType resolveAbstractType(final DeserializationConfig config, final JavaType type) {
-    final AutoMatter annotation = type.getRawClass().getAnnotation(AutoMatter.class);
+    final Class<?> rawClass = type.getRawClass();
+    final AutoMatter annotation = rawClass.getAnnotation(AutoMatter.class);
     if (annotation == null) {
       // This was not an @AutoMatter type.
       return super.resolveAbstractType(config, type);
@@ -32,8 +33,9 @@ class AutoMatterResolver extends AbstractTypeResolver {
     }
 
     // Look up and instantiate the value class
-    final String name = type.getRawClass().getName();
-    final String valueName = name + VALUE_SUFFIX;
+    final String packageName = rawClass.getPackage().getName();
+    final String name = rawClass.getSimpleName();
+    final String valueName = packageName + '.' + name + VALUE_SUFFIX;
     final Class<?> cls;
     try {
       cls = Class.forName(valueName);

--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -20,6 +20,18 @@ public class AutoMatterModuleTest {
       .aCamelCaseField(true)
       .build();
 
+  static final WithInner.Bar BAR = new BarBuilder()
+      .a(17)
+      .b("foobar")
+      .aCamelCaseField(true)
+      .build();
+
+  static final WithInner.PublicBar PUBLIC_BAR = new PublicBarBuilder()
+      .a(17)
+      .b("foobar")
+      .aCamelCaseField(true)
+      .build();
+
   ObjectMapper mapper;
 
   @Before
@@ -33,6 +45,20 @@ public class AutoMatterModuleTest {
     final String json = mapper.writeValueAsString(FOO);
     final Foo parsed = mapper.readValue(json, Foo.class);
     assertThat(parsed, is(FOO));
+  }
+
+  @Test
+  public void testInner() throws IOException {
+    final String json = mapper.writeValueAsString(BAR);
+    final WithInner.Bar parsed = mapper.readValue(json, WithInner.Bar.class);
+    assertThat(parsed, is(BAR));
+  }
+
+  @Test
+  public void testPublicInner() throws IOException {
+    final String json = mapper.writeValueAsString(PUBLIC_BAR);
+    final WithInner.PublicBar parsed = mapper.readValue(json, WithInner.PublicBar.class);
+    assertThat(parsed, is(PUBLIC_BAR));
   }
 
   @Test

--- a/jackson/src/test/java/io/norberg/automatter/jackson/WithInner.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/WithInner.java
@@ -1,0 +1,27 @@
+package io.norberg.automatter.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.norberg.automatter.AutoMatter;
+
+public final class WithInner {
+  @AutoMatter
+  interface Bar {
+    int a();
+    String b();
+    boolean aCamelCaseField();
+
+    @JsonProperty("foobar")
+    boolean isReallyFoobar();
+  }
+
+  @AutoMatter
+  public interface PublicBar {
+    int a();
+    String b();
+    boolean aCamelCaseField();
+
+    @JsonProperty("foobar")
+    boolean isReallyFoobar();
+  }
+}


### PR DESCRIPTION
There's many situations where it's more convenient to just have some simple interfaces inside a class. It's also nice when doing quick prototyping.
