### PR TITLE
Make collections empty by default when parsing json

### DIFF
--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -32,6 +32,9 @@ public class AutoMatterModuleTest {
       .aCamelCaseField(true)
       .build();
 
+  static WithCollections WITH_COLLECTIONS = new WithCollectionsBuilder()
+      .build();
+
   ObjectMapper mapper;
 
   @Before
@@ -80,4 +83,23 @@ public class AutoMatterModuleTest {
     assertThat(parsed, is(FOO));
   }
 
+  @Test
+  public void testEmptyCollections() throws Exception {
+    final String json = mapper.writeValueAsString(WITH_COLLECTIONS);
+    final WithCollections parsed = mapper.readValue(json, WithCollections.class);
+    assertThat(parsed, is(WITH_COLLECTIONS));
+    assertThat(parsed.list().isEmpty(), is(true));
+    assertThat(parsed.set().isEmpty(), is(true));
+    assertThat(parsed.map().isEmpty(), is(true));
+  }
+
+  @Test
+  public void testDefaultEmptyCollections() throws Exception {
+    final String json = "{}";
+    final WithCollections parsed = mapper.readValue(json, WithCollections.class);
+    assertThat(parsed, is(WITH_COLLECTIONS));
+    assertThat(parsed.list().isEmpty(), is(true));
+    assertThat(parsed.set().isEmpty(), is(true));
+    assertThat(parsed.map().isEmpty(), is(true));
+  }
 }

--- a/jackson/src/test/java/io/norberg/automatter/jackson/WithCollections.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/WithCollections.java
@@ -1,0 +1,14 @@
+package io.norberg.automatter.jackson;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface WithCollections {
+  List<String> list();
+  Set<String> set();
+  Map<String, String> map();
+}

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -382,7 +382,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     }
     writer.beginConstructor(EnumSet.of(PRIVATE), parameters, null);
     for (ExecutableElement field : fields) {
-      if (shouldEnforceNonNull(field)) {
+      if (shouldEnforceNonNull(field) && !isCollection(field) && !isMap(field)) {
         emitNullCheck(writer, "", field);
       }
     }

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -355,15 +355,6 @@ public final class CollectionFieldsBuilder
     private Value(@AutoMatter.Field("strings") List<String> strings,
                   @AutoMatter.Field("integers") Map<String,Integer> integers,
                   @AutoMatter.Field("numbers") Set<Long> numbers) {
-      if (strings == null) {
-        throw new NullPointerException("strings");
-      }
-      if (integers == null) {
-        throw new NullPointerException("integers");
-      }
-      if (numbers == null) {
-        throw new NullPointerException("numbers");
-      }
       this.strings = (strings != null) ? strings : Collections.<String>emptyList();
       this.integers = (integers != null) ? integers : Collections.<String,Integer>emptyMap();
       this.numbers = (numbers != null) ? numbers : Collections.<Long>emptySet();


### PR DESCRIPTION
I've run into issues when evolving a schema where existing data does now have keys for new collection fields. The natural behaviour I would expect is that the parsed instances would have empty collections for those fields instead of throwing NPE.