### PR TITLE
Builders Should Not Implement Interface

### DIFF
--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -6,48 +6,26 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import com.squareup.javawriter.JavaWriter;
-
+import io.norberg.automatter.AutoMatter;
 import org.modeshape.common.text.Inflector;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
-import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.Filer;
-import javax.annotation.processing.Messager;
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.Processor;
-import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.tools.JavaFileObject;
-
-import io.norberg.automatter.AutoMatter;
+import java.io.IOException;
+import java.util.*;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Collections.reverse;
 import static javax.lang.model.element.ElementKind.PACKAGE;
-import static javax.lang.model.element.Modifier.FINAL;
-import static javax.lang.model.element.Modifier.PRIVATE;
-import static javax.lang.model.element.Modifier.PUBLIC;
-import static javax.lang.model.element.Modifier.STATIC;
+import static javax.lang.model.element.Modifier.*;
 import static javax.lang.model.type.TypeKind.ARRAY;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
@@ -122,11 +100,10 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     writer.emitAnnotation(
         Generated.class,
         ImmutableMap.of("value", "\"" + AutoMatterProcessor.class.getName() + "\""));
-    writer.beginType(d.builderSimpleName, "class", d.isPublic
-                                                   ? EnumSet.of(PUBLIC, FINAL)
-                                                   : EnumSet.of(FINAL),
-                     null,
-                     d.targetSimpleName);
+    writer.beginType(d.builderSimpleName,
+        "class",
+        d.isPublic ? EnumSet.of(PUBLIC, FINAL) : EnumSet.of(FINAL),
+        null);
     emitFields(writer, d);
     emitConstructors(writer, d);
     emitAccessors(writer, d);
@@ -365,7 +342,6 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     // Only toBuilder if the target asked for it.
     if (descriptor.toBuilder) {
       writer.emitEmptyLine();
-      writer.emitAnnotation(Override.class);
       writer.beginMethod(descriptor.builderFullName, "builder", EnumSet.of(PUBLIC));
       writer.emitStatement("return new %s(this)", descriptor.builderSimpleName);
       writer.endMethod();
@@ -1064,7 +1040,6 @@ public final class AutoMatterProcessor extends AbstractProcessor {
                           final ExecutableElement field)
       throws IOException {
     writer.emitEmptyLine();
-    writer.emitAnnotation(Override.class);
     writer.beginMethod(fieldType(writer, field), fieldName(field), EnumSet.of(PUBLIC));
     if (isCollection(field)) {
       emitCollectionGetterBody(writer, field);

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -16,8 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class CollectionFieldsBuilder
-    implements CollectionFields {
+public final class CollectionFieldsBuilder {
 
   private List<String> strings;
   private Map<String,Integer> integers;
@@ -41,7 +40,6 @@ public final class CollectionFieldsBuilder
     this.numbers = (v.numbers == null) ? null : new HashSet<Long>(v.numbers);
   }
 
-  @Override
   public List<String> strings() {
     if (this.strings == null) {
       this.strings = new ArrayList<String>();
@@ -129,7 +127,6 @@ public final class CollectionFieldsBuilder
     return this;
   }
 
-  @Override
   public Map<String,Integer> integers() {
     if (integers == null) {
       integers = new HashMap<String,Integer>();
@@ -243,7 +240,6 @@ public final class CollectionFieldsBuilder
     return this;
   }
 
-  @Override
   public Set<Long> numbers() {
     if (this.numbers == null) {
       this.numbers = new HashSet<Long>();

--- a/processor/src/test/resources/expected/FooBuilder.java
+++ b/processor/src/test/resources/expected/FooBuilder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class FooBuilder implements Foo {
+public final class FooBuilder {
 
   private boolean aBoolean;
   private byte aByte;
@@ -58,7 +58,6 @@ public final class FooBuilder implements Foo {
     this.array = v.array;
   }
 
-  @Override
   public boolean aBoolean() {
     return aBoolean;
   }
@@ -68,7 +67,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public byte aByte() {
     return aByte;
   }
@@ -78,7 +76,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public short aShort() {
     return aShort;
   }
@@ -88,7 +85,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public int aInt() {
     return aInt;
   }
@@ -98,7 +94,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public long aLong() {
     return aLong;
   }
@@ -108,7 +103,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public char aChar() {
     return aChar;
   }
@@ -118,7 +112,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public float aFloat() {
     return aFloat;
   }
@@ -128,7 +121,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public double aDouble() {
     return aDouble;
   }
@@ -138,7 +130,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public Object object() {
     return object;
   }
@@ -151,7 +142,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public Object[] array() {
     return array;
   }
@@ -164,7 +154,6 @@ public final class FooBuilder implements Foo {
     return this;
   }
 
-  @Override
   public FooBuilder builder() {
     return new FooBuilder(this);
   }

--- a/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
@@ -16,8 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class GuavaOptionalFieldsBuilder
-    implements GuavaOptionalFields {
+public final class GuavaOptionalFieldsBuilder {
 
   private com.google.common.base.Optional<String> foo;
   private com.google.common.base.Optional<String> bar;
@@ -36,7 +35,6 @@ public final class GuavaOptionalFieldsBuilder
     this.bar = v.bar;
   }
 
-  @Override
   public com.google.common.base.Optional<String> foo() {
     return foo;
   }
@@ -53,7 +51,6 @@ public final class GuavaOptionalFieldsBuilder
     return this;
   }
 
-  @Override
   public com.google.common.base.Optional<String> bar() {
     return bar;
   }

--- a/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
@@ -16,8 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class JUTOptionalFieldsBuilder
-    implements JUTOptionalFields {
+public final class JUTOptionalFieldsBuilder {
 
   private java.util.Optional<String> foo;
   private java.util.Optional<String> bar;
@@ -36,7 +35,6 @@ public final class JUTOptionalFieldsBuilder
     this.bar = v.bar;
   }
 
-  @Override
   public java.util.Optional<String> foo() {
     return foo;
   }
@@ -53,7 +51,6 @@ public final class JUTOptionalFieldsBuilder
     return this;
   }
 
-  @Override
   public java.util.Optional<String> bar() {
     return bar;
   }

--- a/processor/src/test/resources/expected/NestedFoobarBuilder.java
+++ b/processor/src/test/resources/expected/NestedFoobarBuilder.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class NestedFoobarBuilder implements Nested.NestedFoobar {
+public final class NestedFoobarBuilder {
 
   public NestedFoobarBuilder() {
   }

--- a/processor/src/test/resources/expected/NestedPackageLocalFoobarBuilder.java
+++ b/processor/src/test/resources/expected/NestedPackageLocalFoobarBuilder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-final class NestedPackageLocalFoobarBuilder implements NestedPackageLocal.NestedPackageLocalFoobar {
+final class NestedPackageLocalFoobarBuilder {
 
   public NestedPackageLocalFoobarBuilder() {
   }

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class NullableCollectionFieldsBuilder implements NullableCollectionFields {
+public final class NullableCollectionFieldsBuilder {
 
   private List<String> strings;
   private Map<String,Integer> integers;
@@ -40,7 +40,6 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     this.numbers = (v.numbers == null) ? null : new HashSet<Long>(v.numbers);
   }
 
-  @Override
   public List<String> strings() {
     return strings;
   }
@@ -110,7 +109,6 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return this;
   }
 
-  @Override
   public Map<String,Integer> integers() {
     return integers;
   }
@@ -178,7 +176,6 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return this;
   }
 
-  @Override
   public Set<Long> numbers() {
     return numbers;
   }

--- a/processor/src/test/resources/expected/NullableFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableFieldsBuilder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class NullableFieldsBuilder implements NullableFields {
+public final class NullableFieldsBuilder {
 
   private String nullableFoo;
   private String customNullableBar;
@@ -40,7 +40,6 @@ public final class NullableFieldsBuilder implements NullableFields {
     this.nonNullPrimitive = v.nonNullPrimitive;
   }
 
-  @Override
   public String nullableFoo() {
     return nullableFoo;
   }
@@ -50,7 +49,6 @@ public final class NullableFieldsBuilder implements NullableFields {
     return this;
   }
 
-  @Override
   public String customNullableBar() {
     return customNullableBar;
   }
@@ -60,7 +58,6 @@ public final class NullableFieldsBuilder implements NullableFields {
     return this;
   }
 
-  @Override
   public String nonNullQuux() {
     return nonNullQuux;
   }
@@ -73,7 +70,6 @@ public final class NullableFieldsBuilder implements NullableFields {
     return this;
   }
 
-  @Override
   public int nonNullPrimitive() {
     return nonNullPrimitive;
   }

--- a/processor/src/test/resources/expected/PackageLocalBuilder.java
+++ b/processor/src/test/resources/expected/PackageLocalBuilder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-final class PackageLocalBuilder implements PackageLocal {
+final class PackageLocalBuilder {
 
   public PackageLocalBuilder() {
   }

--- a/processor/src/test/resources/expected/TopLevelBuilder.java
+++ b/processor/src/test/resources/expected/TopLevelBuilder.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
-public final class TopLevelBuilder implements TopLevel {
+public final class TopLevelBuilder {
 
   public TopLevelBuilder() {
   }

--- a/test/src/test/java/io/norberg/automatter/BuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/BuilderTest.java
@@ -7,6 +7,7 @@ import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -39,6 +40,9 @@ public class BuilderTest {
     assertThat(foobar.foo(), is(0));
     assertThat(foobar.bar(), is("bar"));
     assertThat(foobar.quux(), is(nullValue()));
+
+    // Ensure that builders are not instances of the interface, avoiding bugs
+    assertThat(builder, is(not(instanceOf(Foobar.class))));
   }
 
   @Test


### PR DESCRIPTION
It might be convenient sometimes, but this can lead to some bugs because the compiler can not check us missing the `build()` method.

```java
@AutoMatter
interface Value {
...
}

// Compiler can't check that we didn't call build, bugs arise at runtime
Value v = new ValueBuilder();
```

Now bugs arise, for example, equality checking:
```java
if (v.equals(otherBuiltValue)) {
 // This is broken, comparing memory
}
```

Or with Jackson serialization:
```java
// Throws an exception because we can't serialize the builder
objectMapper.writeValue(v); 
```

Could accidentally modify lists and maps
```java
v.items().append("i");
```

All of these can be caught by making the Builder class not implement its value object. But this would probably be a breaking API change.

