### PR TITLE
Allow Builders to Clear or Replace Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Foobar foobar = new FoobarBuilder()
     .addOx("mooo!!")
     .addCow("moooo!!!")
     .foo(17, 18)
-    .addAge("cassie", 5)
-    .addAge("henrietta", 7)
+    .putAge("cassie", 5)
+    .putAge("henrietta", 7)
     .build();
 
 assert foobar.oxen().equals(asList("moo!", "mooo!!"));

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ interface Foobar {
 // ...
 
 Foobar foobar = new FoobarBuilder()
-    .appendOx("moo!")
-    .appendOx("mooo!!")
-    .appendCow("moooo!!!")
+    .addOx("moo!")
+    .addOx("mooo!!")
+    .addCow("moooo!!!")
     .foo(17, 18)
     .addAge("cassie", 5)
     .addAge("henrietta", 7)

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ interface Foobar {
 // ...
 
 Foobar foobar = new FoobarBuilder()
-    .ox("moo!")
-    .ox("mooo!!")
-    .cow("moooo!!!")
+    .appendOx("moo!")
+    .appendOx("mooo!!")
+    .appendCow("moooo!!!")
     .foo(17, 18)
     .age("cassie", 5)
     .age("henrietta", 7)

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Foobar foobar = new FoobarBuilder()
     .appendOx("mooo!!")
     .appendCow("moooo!!!")
     .foo(17, 18)
-    .age("cassie", 5)
-    .age("henrietta", 7)
+    .addAge("cassie", 5)
+    .addAge("henrietta", 7)
     .build();
 
 assert foobar.oxen().equals(asList("moo!", "mooo!!"));

--- a/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
+++ b/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
@@ -25,8 +25,8 @@ public class CollectionExample {
         .appendOx("mooo!!")
         .appendCow("moooo!!!")
         .foo(17, 18)
-        .age("cassie", 5)
-        .age("henrietta", 7)
+        .addAge("cassie", 5)
+        .addAge("henrietta", 7)
         .build();
 
     out.println("oxen: " + foobar.oxen());

--- a/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
+++ b/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
@@ -1,10 +1,10 @@
 package io.norberg.automatter.example;
 
+import io.norberg.automatter.AutoMatter;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
-import io.norberg.automatter.AutoMatter;
 
 import static java.lang.System.out;
 
@@ -21,9 +21,9 @@ public class CollectionExample {
 
   public static void main(final String... args) throws IOException {
     CollectionsFoobar foobar = new CollectionsFoobarBuilder()
-        .ox("moo!")
-        .ox("mooo!!")
-        .cow("moooo!!!")
+        .appendOx("moo!")
+        .appendOx("mooo!!")
+        .appendCow("moooo!!!")
         .foo(17, 18)
         .age("cassie", 5)
         .age("henrietta", 7)

--- a/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
+++ b/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
@@ -21,9 +21,9 @@ public class CollectionExample {
 
   public static void main(final String... args) throws IOException {
     CollectionsFoobar foobar = new CollectionsFoobarBuilder()
-        .appendOx("moo!")
-        .appendOx("mooo!!")
-        .appendCow("moooo!!!")
+        .addOx("moo!")
+        .addOx("mooo!!")
+        .addCow("moooo!!!")
         .foo(17, 18)
         .addAge("cassie", 5)
         .addAge("henrietta", 7)

--- a/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
+++ b/example/src/main/java/io/norberg/automatter/example/CollectionExample.java
@@ -25,8 +25,8 @@ public class CollectionExample {
         .addOx("mooo!!")
         .addCow("moooo!!!")
         .foo(17, 18)
-        .addAge("cassie", 5)
-        .addAge("henrietta", 7)
+        .putAge("cassie", 5)
+        .putAge("henrietta", 7)
         .build();
 
     out.println("oxen: " + foobar.oxen());

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -702,11 +702,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
       writer.endControlFlow();
     }
 
-    writer.beginControlFlow("if (this." + name + " == null)");
     writer.emitStatement("this.%1$s = new HashMap<%2$s>(%1$s)", name, type);
-    writer.nextControlFlow("else");
-    writer.emitStatement("this.%1$s.putAll(%1$s)", name);
-    writer.endControlFlow();
 
     writer.emitStatement("return this");
     writer.endMethod();
@@ -751,9 +747,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
 
     // Map instantiation
     if (entries == 1) {
-      writer.beginControlFlow("if (" + name + " == null)");
       writer.emitStatement("%s = new HashMap<%s>()", name, fieldTypeArguments(writer, field));
-      writer.endControlFlow();
     }
 
     // Put
@@ -783,11 +777,12 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     if (singular == null) {
       return;
     }
+    final String addSingular = "add" + capitalizeFirstLetter(singular);
     final String keyType = keyType(writer, field);
     final String valueType = valueType(writer, field);
 
     writer.emitEmptyLine();
-    writer.beginMethod(builderName, singular, EnumSet.of(PUBLIC),
+    writer.beginMethod(builderName, addSingular, EnumSet.of(PUBLIC),
                        keyType, "key", valueType, "value");
 
     // Null checks
@@ -1202,7 +1197,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     messager.printMessage(ERROR, s, element);
   }
 
-  private String capitalizeFirstLetter(String s) {
+  private static String capitalizeFirstLetter(String s) {
     if (s == null) {
       throw new NullPointerException("s");
     }

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -777,7 +777,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     if (singular == null) {
       return;
     }
-    final String addSingular = "add" + capitalizeFirstLetter(singular);
+    final String addSingular = "put" + capitalizeFirstLetter(singular);
     final String keyType = keyType(writer, field);
     final String valueType = valueType(writer, field);
 

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -852,7 +852,7 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     if (singular == null || singular.isEmpty()) {
       return;
     }
-    final String appendMethodName = "append" + capitalizeFirstLetter(singular);
+    final String appendMethodName = "add" + capitalizeFirstLetter(singular);
     writer.emitEmptyLine();
     writer.beginMethod(builderName, appendMethodName, EnumSet.of(PUBLIC),
                        fieldTypeArguments(writer, field), singular);

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -57,21 +57,12 @@ public final class CollectionFieldsBuilder
     if (strings == null) {
       throw new NullPointerException("strings");
     }
-    if (this.strings == null) {
-      for (String item : strings) {
-        if (item == null) {
-          throw new NullPointerException("strings: null item");
-        }
-      }
-      this.strings = new ArrayList<String>(strings);
-    } else {
-      for (String item : strings) {
-        if (item == null) {
-          throw new NullPointerException("strings: null item");
-        }
-        this.strings.add(item);
+    for (String item : strings) {
+      if (item == null) {
+        throw new NullPointerException("strings: null item");
       }
     }
+    this.strings = new ArrayList<String>(strings);
     return this;
   }
 
@@ -82,25 +73,15 @@ public final class CollectionFieldsBuilder
     if (strings instanceof Collection) {
       return strings((Collection<? extends String>) strings);
     }
-    if (this.strings == null) {
-      this.strings = new ArrayList<String>();
-    }
-    for (String item : strings) {
-      if (item == null) {
-        throw new NullPointerException("strings: null item");
-      }
-      this.strings.add(item);
-    }
-    return this;
+    return strings(strings.iterator());
   }
 
   public CollectionFieldsBuilder strings(Iterator<? extends String> strings) {
     if (strings == null) {
       throw new NullPointerException("strings");
     }
-    if (this.strings == null) {
-      this.strings = new ArrayList<String>();
-    }
+
+    this.strings = new ArrayList<String>();
     while (strings.hasNext()) {
       String item = strings.next();
       if (item == null) {
@@ -118,7 +99,7 @@ public final class CollectionFieldsBuilder
     return strings(Arrays.asList(strings));
   }
 
-  public CollectionFieldsBuilder string(String string) {
+  public CollectionFieldsBuilder appendString(String string) {
     if (string == null) {
       throw new NullPointerException("string");
     }
@@ -259,21 +240,12 @@ public final class CollectionFieldsBuilder
     if (numbers == null) {
       throw new NullPointerException("numbers");
     }
-    if (this.numbers == null) {
-      for (Long item : numbers) {
-        if (item == null) {
-          throw new NullPointerException("numbers: null item");
-        }
-      }
-      this.numbers = new HashSet<Long>(numbers);
-    } else {
-      for (Long item : numbers) {
-        if (item == null) {
-          throw new NullPointerException("numbers: null item");
-        }
-        this.numbers.add(item);
+    for (Long item : numbers) {
+      if (item == null) {
+        throw new NullPointerException("numbers: null item");
       }
     }
+    this.numbers = new HashSet<Long>(numbers);
     return this;
   }
 
@@ -284,25 +256,14 @@ public final class CollectionFieldsBuilder
     if (numbers instanceof Collection) {
       return numbers((Collection<? extends Long>) numbers);
     }
-    if (this.numbers == null) {
-      this.numbers = new HashSet<Long>();
-    }
-    for (Long item : numbers) {
-      if (item == null) {
-        throw new NullPointerException("numbers: null item");
-      }
-      this.numbers.add(item);
-    }
-    return this;
+    return numbers(numbers.iterator());
   }
 
   public CollectionFieldsBuilder numbers(Iterator<? extends Long> numbers) {
     if (numbers == null) {
       throw new NullPointerException("numbers");
     }
-    if (this.numbers == null) {
-      this.numbers = new HashSet<Long>();
-    }
+    this.numbers = new HashSet<Long>();
     while (numbers.hasNext()) {
       Long item = numbers.next();
       if (item == null) {
@@ -320,7 +281,7 @@ public final class CollectionFieldsBuilder
     return numbers(Arrays.asList(numbers));
   }
 
-  public CollectionFieldsBuilder number(Long number) {
+  public CollectionFieldsBuilder appendNumber(Long number) {
     if (number == null) {
       throw new NullPointerException("number");
     }

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -130,11 +130,7 @@ public final class CollectionFieldsBuilder
         throw new NullPointerException("integers: null value");
       }
     }
-    if (this.integers == null) {
-      this.integers = new HashMap<String,Integer>(integers);
-    } else {
-      this.integers.putAll(integers);
-    }
+    this.integers = new HashMap<String,Integer>(integers);
     return this;
   }
 
@@ -145,9 +141,7 @@ public final class CollectionFieldsBuilder
     if (v1 == null) {
       throw new NullPointerException("integers: v1");
     }
-    if (integers == null) {
-      integers = new HashMap<String,Integer>();
-    }
+    integers = new HashMap<String,Integer>();
     integers.put(k1, v1);
     return this;
   }
@@ -210,7 +204,7 @@ public final class CollectionFieldsBuilder
     return this;
   }
 
-  public CollectionFieldsBuilder integer(String key, Integer value) {
+  public CollectionFieldsBuilder addInteger(String key, Integer value) {
     if (key == null) {
       throw new NullPointerException("integer: key");
     }

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -204,7 +204,7 @@ public final class CollectionFieldsBuilder
     return this;
   }
 
-  public CollectionFieldsBuilder addInteger(String key, Integer value) {
+  public CollectionFieldsBuilder putInteger(String key, Integer value) {
     if (key == null) {
       throw new NullPointerException("integer: key");
     }

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -99,7 +99,7 @@ public final class CollectionFieldsBuilder
     return strings(Arrays.asList(strings));
   }
 
-  public CollectionFieldsBuilder appendString(String string) {
+  public CollectionFieldsBuilder addString(String string) {
     if (string == null) {
       throw new NullPointerException("string");
     }
@@ -275,7 +275,7 @@ public final class CollectionFieldsBuilder
     return numbers(Arrays.asList(numbers));
   }
 
-  public CollectionFieldsBuilder appendNumber(Long number) {
+  public CollectionFieldsBuilder addNumber(Long number) {
     if (number == null) {
       throw new NullPointerException("number");
     }

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -108,18 +108,12 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
       this.integers = null;
       return this;
     }
-    if (this.integers == null) {
-      this.integers = new HashMap<String,Integer>(integers);
-    } else {
-      this.integers.putAll(integers);
-    }
+    this.integers = new HashMap<String,Integer>(integers);
     return this;
   }
 
   public NullableCollectionFieldsBuilder integers(String k1, Integer v1) {
-    if (integers == null) {
-      integers = new HashMap<String,Integer>();
-    }
+    integers = new HashMap<String,Integer>();
     integers.put(k1, v1);
     return this;
   }
@@ -158,7 +152,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return this;
   }
 
-  public NullableCollectionFieldsBuilder integer(String key, Integer value) {
+  public NullableCollectionFieldsBuilder addInteger(String key, Integer value) {
     if (integers == null) {
       integers = new HashMap<String,Integer>();
     }

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -152,7 +152,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return this;
   }
 
-  public NullableCollectionFieldsBuilder addInteger(String key, Integer value) {
+  public NullableCollectionFieldsBuilder putInteger(String key, Integer value) {
     if (integers == null) {
       integers = new HashMap<String,Integer>();
     }

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -54,11 +54,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
       this.strings = null;
       return this;
     }
-    if (this.strings == null) {
-      this.strings = new ArrayList<String>(strings);
-    } else {
-      this.strings.addAll(strings);
-    }
+    this.strings = new ArrayList<String>(strings);
     return this;
   }
 
@@ -70,13 +66,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     if (strings instanceof Collection) {
       return strings((Collection<? extends String>) strings);
     }
-    if (this.strings == null) {
-      this.strings = new ArrayList<String>();
-    }
-    for (String item : strings) {
-      this.strings.add(item);
-    }
-    return this;
+    return strings(strings.iterator());
   }
 
   public NullableCollectionFieldsBuilder strings(Iterator<? extends String> strings) {
@@ -84,9 +74,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
       this.strings = null;
       return this;
     }
-    if (this.strings == null) {
-      this.strings = new ArrayList<String>();
-    }
+    this.strings = new ArrayList<String>();
     while (strings.hasNext()) {
       String item = strings.next();
       this.strings.add(item);
@@ -102,7 +90,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return strings(Arrays.asList(strings));
   }
 
-  public NullableCollectionFieldsBuilder string(String string) {
+  public NullableCollectionFieldsBuilder appendString(String string) {
     if (this.strings == null) {
       this.strings = new ArrayList<String>();
     }
@@ -192,11 +180,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
       this.numbers = null;
       return this;
     }
-    if (this.numbers == null) {
-      this.numbers = new HashSet<Long>(numbers);
-    } else {
-      this.numbers.addAll(numbers);
-    }
+    this.numbers = new HashSet<Long>(numbers);
     return this;
   }
 
@@ -208,13 +192,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     if (numbers instanceof Collection) {
       return numbers((Collection<? extends Long>) numbers);
     }
-    if (this.numbers == null) {
-      this.numbers = new HashSet<Long>();
-    }
-    for (Long item : numbers) {
-      this.numbers.add(item);
-    }
-    return this;
+    return numbers(numbers.iterator());
   }
 
   public NullableCollectionFieldsBuilder numbers(Iterator<? extends Long> numbers) {
@@ -222,9 +200,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
       this.numbers = null;
       return this;
     }
-    if (this.numbers == null) {
-      this.numbers = new HashSet<Long>();
-    }
+    this.numbers = new HashSet<Long>();
     while (numbers.hasNext()) {
       Long item = numbers.next();
       this.numbers.add(item);
@@ -240,7 +216,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return numbers(Arrays.asList(numbers));
   }
 
-  public NullableCollectionFieldsBuilder number(Long number) {
+  public NullableCollectionFieldsBuilder appendNumber(Long number) {
     if (this.numbers == null) {
       this.numbers = new HashSet<Long>();
     }

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -90,7 +90,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return strings(Arrays.asList(strings));
   }
 
-  public NullableCollectionFieldsBuilder appendString(String string) {
+  public NullableCollectionFieldsBuilder addString(String string) {
     if (this.strings == null) {
       this.strings = new ArrayList<String>();
     }
@@ -210,7 +210,7 @@ public final class NullableCollectionFieldsBuilder implements NullableCollection
     return numbers(Arrays.asList(numbers));
   }
 
-  public NullableCollectionFieldsBuilder appendNumber(Long number) {
+  public NullableCollectionFieldsBuilder addNumber(Long number) {
     if (this.numbers == null) {
       this.numbers = new HashSet<Long>();
     }

--- a/test/src/test/java/io/norberg/automatter/ListFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/ListFieldBuilderTest.java
@@ -43,7 +43,7 @@ public class ListFieldBuilderTest {
 
   @Test
   public void verifyBuilderListIsMutable() {
-    builder.appendApple("red");
+    builder.addApple("red");
     final List<String> apples = builder.apples();
     apples.remove("red");
     apples.add("green");
@@ -57,7 +57,7 @@ public class ListFieldBuilderTest {
     final Lists lists1 = builder
         .apples("red")
         .build();
-    builder.appendApple("green");
+    builder.addApple("green");
     final Lists lists2 = builder.build();
     assertThat(lists1.apples(), is(asList("red")));
     assertThat(lists2.apples(), is(asList("red", "green")));
@@ -66,7 +66,7 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable1() {
     final Lists lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().remove("red");
   }
@@ -74,7 +74,7 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable2() {
     final Lists lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().add("blue");
   }
@@ -82,14 +82,14 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable3() {
     final Lists lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Lists lists = builder.appendOx(17).appendOx(4711).build();
+    final Lists lists = builder.addOx(17).addOx(4711).build();
     assertThat(lists.oxen(), is(asList(17, 4711)));
   }
 
@@ -103,7 +103,7 @@ public class ListFieldBuilderTest {
   public void verifyAddingNullThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("apple");
-    builder.appendApple(null);
+    builder.addApple(null);
   }
 
   @Test

--- a/test/src/test/java/io/norberg/automatter/ListFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/ListFieldBuilderTest.java
@@ -2,7 +2,6 @@ package io.norberg.automatter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +43,7 @@ public class ListFieldBuilderTest {
 
   @Test
   public void verifyBuilderListIsMutable() {
-    builder.apple("red");
+    builder.appendApple("red");
     final List<String> apples = builder.apples();
     apples.remove("red");
     apples.add("green");
@@ -58,7 +57,7 @@ public class ListFieldBuilderTest {
     final Lists lists1 = builder
         .apples("red")
         .build();
-    builder.apple("green");
+    builder.appendApple("green");
     final Lists lists2 = builder.build();
     assertThat(lists1.apples(), is(asList("red")));
     assertThat(lists2.apples(), is(asList("red", "green")));
@@ -67,7 +66,7 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable1() {
     final Lists lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().remove("red");
   }
@@ -75,7 +74,7 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable2() {
     final Lists lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().add("blue");
   }
@@ -83,20 +82,20 @@ public class ListFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable3() {
     final Lists lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Lists lists = builder.ox(17).ox(4711).build();
+    final Lists lists = builder.appendOx(17).appendOx(4711).build();
     assertThat(lists.oxen(), is(asList(17, 4711)));
   }
 
   @Test
   public void testSingular() {
-    final Lists lists = builder.serial(1, 2, 3,4).build();
+    final Lists lists = builder.serial(1, 2, 3, 4).build();
     assertThat(lists.serial(), is(asList(1, 2, 3, 4)));
   }
 
@@ -104,7 +103,7 @@ public class ListFieldBuilderTest {
   public void verifyAddingNullThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("apple");
-    builder.apple(null);
+    builder.appendApple(null);
   }
 
   @Test
@@ -124,5 +123,20 @@ public class ListFieldBuilderTest {
   @Test
   public void verifySettingExtendingValue() {
     builder.maps(ImmutableList.of(ImmutableMap.of("foo", 17)));
+  }
+
+  @Test
+  public void testListMethodsReplaceOldValue() {
+    final Lists list = builder
+        .apples("red", "green")
+        .apples("green")
+        .build();
+
+    assertThat(list.apples(), is(asList("green")));
+
+    final Lists listWithRed = ListsBuilder.from(list)
+        .apples("red")
+        .build();
+    assertThat(listWithRed.apples(), is(asList("red")));
   }
 }

--- a/test/src/test/java/io/norberg/automatter/MapFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/MapFieldBuilderTest.java
@@ -44,7 +44,7 @@ public class MapFieldBuilderTest {
 
   @Test
   public void verifyBuilderMapIsMutable() {
-    builder.price("apple", 17);
+    builder.addPrice("apple", 17);
     final Map<String, Integer> prices = builder.prices();
     prices.remove("apple");
     prices.put("orange", 18);
@@ -58,7 +58,7 @@ public class MapFieldBuilderTest {
     final Maps maps1 = builder
         .prices("apple", 17)
         .build();
-    builder.price("orange", 18);
+    builder.addPrice("orange", 18);
     final Maps maps2 = builder.build();
     assertThat(maps1.prices(), is(singletonMap("apple", 17)));
     assertEquals(ImmutableMap.of("apple", 17, "orange", 18), maps2.prices());
@@ -103,11 +103,11 @@ public class MapFieldBuilderTest {
 
   @Test
   public void testPuttingAdditionalEntries() {
-    builder.price("a", 1);
+    builder.addPrice("a", 1);
     assertEquals(ImmutableMap.of("a", 1), builder.prices());
     assertEquals(ImmutableMap.of("a", 1), builder.build().prices());
 
-    builder.price("b", 2);
+    builder.addPrice("b", 2);
     assertEquals(ImmutableMap.of("a", 1, "b", 2), builder.prices());
     assertEquals(ImmutableMap.of("a", 1, "b", 2), builder.build().prices());
   }
@@ -115,8 +115,8 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueMapIsImmutable1() {
     final Maps maps = builder
-        .price("apple", 17)
-        .price("orange", 18)
+        .addPrice("apple", 17)
+        .addPrice("orange", 18)
         .build();
     maps.prices().remove("apple");
   }
@@ -124,7 +124,7 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable2() {
     final Maps maps = builder
-        .price("apple", 17)
+        .addPrice("apple", 17)
         .build();
     maps.prices().put("orange", 18);
   }
@@ -132,14 +132,14 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable3() {
     final Maps maps = builder
-        .price("apple", 17)
+        .addPrice("apple", 17)
         .build();
     maps.prices().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Maps maps = builder.ox(17, "foo").ox(4711, "bar").build();
+    final Maps maps = builder.addOx(17, "foo").addOx(4711, "bar").build();
     assertEquals(ImmutableMap.of(17, "foo", 4711, "bar"), maps.oxen());
   }
 
@@ -153,14 +153,14 @@ public class MapFieldBuilderTest {
   public void verifyPuttingNullKeyThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("price: key");
-    builder.price(null, 17);
+    builder.addPrice(null, 17);
   }
 
   @Test
   public void verifyPuttingNullValueThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("price: value");
-    builder.price("apple", null);
+    builder.addPrice("apple", null);
   }
 
   @Test
@@ -173,5 +173,19 @@ public class MapFieldBuilderTest {
   @Test
   public void verifySettingExtendingValue() {
     builder.lists(ImmutableMap.of(1, ImmutableList.of("foo", "bar")));
+  }
+
+  @Test
+  public void verifyMapMethodsReplaceValue() {
+    final Maps onlyApples = builder.prices("apples", 2, "pears", 3)
+        .prices("apples", 4)
+        .build();
+
+    assertEquals(ImmutableMap.of("apples", 4), onlyApples.prices());
+
+    final Maps pearsAndOranges = MapsBuilder.from(onlyApples)
+        .prices("pears", 5, "orange", 6)
+        .build();
+    assertEquals(ImmutableMap.of("pears", 5, "orange", 6), pearsAndOranges.prices());
   }
 }

--- a/test/src/test/java/io/norberg/automatter/MapFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/MapFieldBuilderTest.java
@@ -44,7 +44,7 @@ public class MapFieldBuilderTest {
 
   @Test
   public void verifyBuilderMapIsMutable() {
-    builder.addPrice("apple", 17);
+    builder.putPrice("apple", 17);
     final Map<String, Integer> prices = builder.prices();
     prices.remove("apple");
     prices.put("orange", 18);
@@ -58,7 +58,7 @@ public class MapFieldBuilderTest {
     final Maps maps1 = builder
         .prices("apple", 17)
         .build();
-    builder.addPrice("orange", 18);
+    builder.putPrice("orange", 18);
     final Maps maps2 = builder.build();
     assertThat(maps1.prices(), is(singletonMap("apple", 17)));
     assertEquals(ImmutableMap.of("apple", 17, "orange", 18), maps2.prices());
@@ -103,11 +103,11 @@ public class MapFieldBuilderTest {
 
   @Test
   public void testPuttingAdditionalEntries() {
-    builder.addPrice("a", 1);
+    builder.putPrice("a", 1);
     assertEquals(ImmutableMap.of("a", 1), builder.prices());
     assertEquals(ImmutableMap.of("a", 1), builder.build().prices());
 
-    builder.addPrice("b", 2);
+    builder.putPrice("b", 2);
     assertEquals(ImmutableMap.of("a", 1, "b", 2), builder.prices());
     assertEquals(ImmutableMap.of("a", 1, "b", 2), builder.build().prices());
   }
@@ -115,8 +115,8 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueMapIsImmutable1() {
     final Maps maps = builder
-        .addPrice("apple", 17)
-        .addPrice("orange", 18)
+        .putPrice("apple", 17)
+        .putPrice("orange", 18)
         .build();
     maps.prices().remove("apple");
   }
@@ -124,7 +124,7 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable2() {
     final Maps maps = builder
-        .addPrice("apple", 17)
+        .putPrice("apple", 17)
         .build();
     maps.prices().put("orange", 18);
   }
@@ -132,14 +132,14 @@ public class MapFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueListIsImmutable3() {
     final Maps maps = builder
-        .addPrice("apple", 17)
+        .putPrice("apple", 17)
         .build();
     maps.prices().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Maps maps = builder.addOx(17, "foo").addOx(4711, "bar").build();
+    final Maps maps = builder.putOx(17, "foo").putOx(4711, "bar").build();
     assertEquals(ImmutableMap.of(17, "foo", 4711, "bar"), maps.oxen());
   }
 
@@ -153,14 +153,14 @@ public class MapFieldBuilderTest {
   public void verifyPuttingNullKeyThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("price: key");
-    builder.addPrice(null, 17);
+    builder.putPrice(null, 17);
   }
 
   @Test
   public void verifyPuttingNullValueThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("price: value");
-    builder.addPrice("apple", null);
+    builder.putPrice("apple", null);
   }
 
   @Test

--- a/test/src/test/java/io/norberg/automatter/NullableListFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/NullableListFieldBuilderTest.java
@@ -5,14 +5,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class NullableListFieldBuilderTest {
@@ -39,7 +36,7 @@ public class NullableListFieldBuilderTest {
 
   @Test
   public void testAddingItemInstantiatesList() {
-    builder.apple("red");
+    builder.appendApple("red");
     final NullableLists lists = builder.build();
     assertThat(lists.apples(), is(asList("red")));
   }
@@ -68,7 +65,7 @@ public class NullableListFieldBuilderTest {
 
   @Test
   public void testAddingNull() {
-    builder.apple(null);
+    builder.appendApple(null);
     final NullableLists lists = builder.build();
     List<String> apples = lists.apples();
     assertThat(apples, is(notNullValue()));

--- a/test/src/test/java/io/norberg/automatter/NullableListFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/NullableListFieldBuilderTest.java
@@ -36,7 +36,7 @@ public class NullableListFieldBuilderTest {
 
   @Test
   public void testAddingItemInstantiatesList() {
-    builder.appendApple("red");
+    builder.addApple("red");
     final NullableLists lists = builder.build();
     assertThat(lists.apples(), is(asList("red")));
   }
@@ -65,7 +65,7 @@ public class NullableListFieldBuilderTest {
 
   @Test
   public void testAddingNull() {
-    builder.appendApple(null);
+    builder.addApple(null);
     final NullableLists lists = builder.build();
     List<String> apples = lists.apples();
     assertThat(apples, is(notNullValue()));

--- a/test/src/test/java/io/norberg/automatter/NullableMapFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/NullableMapFieldBuilderTest.java
@@ -1,19 +1,15 @@
 package io.norberg.automatter;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertThat;
 
@@ -41,7 +37,7 @@ public class NullableMapFieldBuilderTest {
 
   @Test
   public void testAddingEntryInstantiatesMap() {
-    builder.price("red", 17);
+    builder.addPrice("red", 17);
     final NullableMap map = builder.build();
     assertThat(map.prices(), is((Map<String, Integer>)ImmutableMap.of("red", 17)));
   }

--- a/test/src/test/java/io/norberg/automatter/NullableMapFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/NullableMapFieldBuilderTest.java
@@ -37,7 +37,7 @@ public class NullableMapFieldBuilderTest {
 
   @Test
   public void testAddingEntryInstantiatesMap() {
-    builder.addPrice("red", 17);
+    builder.putPrice("red", 17);
     final NullableMap map = builder.build();
     assertThat(map.prices(), is((Map<String, Integer>)ImmutableMap.of("red", 17)));
   }

--- a/test/src/test/java/io/norberg/automatter/SetFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/SetFieldBuilderTest.java
@@ -40,7 +40,7 @@ public class SetFieldBuilderTest {
 
   @Test
   public void verifyBuilderSetIsMutable() {
-    builder.apple("red");
+    builder.appendApple("red");
     final Set<String> apples = builder.apples();
     apples.remove("red");
     apples.add("green");
@@ -54,7 +54,7 @@ public class SetFieldBuilderTest {
     final Sets lists1 = builder
         .apples("red")
         .build();
-    builder.apple("green");
+    builder.appendApple("green");
     final Sets lists2 = builder.build();
     assertThat(lists1.apples(), is(set("red")));
     assertThat(lists2.apples(), is(set("red", "green")));
@@ -63,7 +63,7 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable1() {
     final Sets lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().remove("red");
   }
@@ -71,7 +71,7 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable2() {
     final Sets lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().add("blue");
   }
@@ -79,14 +79,14 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable3() {
     final Sets lists = builder
-        .apple("red").apple("green")
+        .appendApple("red").appendApple("green")
         .build();
     lists.apples().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Sets lists = builder.ox(17).ox(4711).build();
+    final Sets lists = builder.appendOx(17).appendOx(4711).build();
     assertThat(lists.oxen(), is(set(17, 4711)));
   }
 
@@ -100,7 +100,7 @@ public class SetFieldBuilderTest {
   public void verifyAddingNullThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("apple");
-    builder.apple(null);
+    builder.appendApple(null);
   }
 
   @Test

--- a/test/src/test/java/io/norberg/automatter/SetFieldBuilderTest.java
+++ b/test/src/test/java/io/norberg/automatter/SetFieldBuilderTest.java
@@ -40,7 +40,7 @@ public class SetFieldBuilderTest {
 
   @Test
   public void verifyBuilderSetIsMutable() {
-    builder.appendApple("red");
+    builder.addApple("red");
     final Set<String> apples = builder.apples();
     apples.remove("red");
     apples.add("green");
@@ -54,7 +54,7 @@ public class SetFieldBuilderTest {
     final Sets lists1 = builder
         .apples("red")
         .build();
-    builder.appendApple("green");
+    builder.addApple("green");
     final Sets lists2 = builder.build();
     assertThat(lists1.apples(), is(set("red")));
     assertThat(lists2.apples(), is(set("red", "green")));
@@ -63,7 +63,7 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable1() {
     final Sets lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().remove("red");
   }
@@ -71,7 +71,7 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable2() {
     final Sets lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().add("blue");
   }
@@ -79,14 +79,14 @@ public class SetFieldBuilderTest {
   @Test(expected = UnsupportedOperationException.class)
   public void verifyValueSetIsImmutable3() {
     final Sets lists = builder
-        .appendApple("red").appendApple("green")
+        .addApple("red").addApple("green")
         .build();
     lists.apples().clear();
   }
 
   @Test
   public void testEnglishPlurals() {
-    final Sets lists = builder.appendOx(17).appendOx(4711).build();
+    final Sets lists = builder.addOx(17).addOx(4711).build();
     assertThat(lists.oxen(), is(set(17, 4711)));
   }
 
@@ -100,7 +100,7 @@ public class SetFieldBuilderTest {
   public void verifyAddingNullThrowsNPE() {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage("apple");
-    builder.appendApple(null);
+    builder.addApple(null);
   }
 
   @Test


### PR DESCRIPTION
Consider the following:

```java
@AutoMatter
public interface Value {
  List<String> strings();
}

Value a = ValueBuilder.strings("a", "b").build();
Value b = ValueBuilder.from(a).strings("c").build();
```

As a user I would expect: `b.strings() => ["c"]` but its not. `b.strings() => ["a", "b", "c"]` because of the collections style it is implemented with. 

Thus to clear the list becomes very painful, and not very usable with the builder pattern:

```java
ValueBuilder builder = ValueBuilder.from(a);
builder.strings().clear();
Value b = builder.strings("c").build();
```

I propose one of the following solutions, in order of my preference

### New `setStrings(Collection<?>)` method

The `setStrings` would replace the strings list completely.

```java
// Other overrides for varargs, iterables, collections would exist
Value b = ValueBuilder.from(a).setStrings("c").build();
```

### New `clearStrings()` method

This would clear the list

```java
Value b = ValueBuilder.from(a).clearStrings().strings("c").build();
```

### Make `strings()` replace, and only do collection actions for the `string()` method

That is, break the current API

```java
Value b = ValueBuilder.from(a).strings("c").build(); 
// b => ["c"]

Value c = ValueBuilder.from(a).string("c").build(); 
// c => ["a", "b", "c"]
```