### PR TITLE
RFC: Port processor to javapoet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
   - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -24,11 +24,6 @@
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>
-      <artifactId>javawriter</artifactId>
-      <version>2.4.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup</groupId>
       <artifactId>javapoet</artifactId>
       <version>1.0.0</version>
     </dependency>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -28,6 +28,11 @@
       <version>2.4.0</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>18.0</version>

--- a/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
+++ b/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
@@ -2,13 +2,11 @@ package io.norberg.automatter;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-
+import io.norberg.automatter.processor.AutoMatterProcessor;
 import org.junit.Assume;
 import org.junit.Test;
 
 import javax.tools.JavaFileObject;
-
-import io.norberg.automatter.processor.AutoMatterProcessor;
 
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -2,10 +2,12 @@ package foo;
 
 import io.norberg.automatter.AutoMatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,8 +107,8 @@ public final class CollectionFieldsBuilder {
   }
 
   public Map<String,Integer> integers() {
-    if (integers == null) {
-      integers = new HashMap<String,Integer>();
+    if (this.integers == null) {
+      this.integers = new HashMap<String,Integer>();
     }
     return integers;
   }
@@ -204,8 +206,8 @@ public final class CollectionFieldsBuilder {
     if (value == null) {
       throw new NullPointerException("integer: value");
     }
-    if (integers == null) {
-      integers = new HashMap<String,Integer>();
+    if (this.integers == null) {
+      this.integers = new HashMap<String,Integer>();
     }
     integers.put(key, value);
     return this;

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -2,6 +2,7 @@ package foo;
 
 import io.norberg.automatter.AutoMatter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -278,9 +279,10 @@ public final class CollectionFieldsBuilder {
   }
 
   public CollectionFields build() {
-    return new Value((strings != null) ? Collections.unmodifiableList(new ArrayList<String>(strings)) : Collections.<String>emptyList(),
-                     (integers != null) ? Collections.unmodifiableMap(new HashMap<String,Integer>(integers)) : Collections.<String,Integer>emptyMap(),
-                     (numbers != null) ? Collections.unmodifiableSet(new HashSet<Long>(numbers)) : Collections.<Long>emptySet());
+    List<String> _strings = (strings != null) ? Collections.unmodifiableList(new ArrayList<String>(strings)) : Collections.<String>emptyList();
+    Map<String, Integer> _integers = (integers != null) ? Collections.unmodifiableMap(new HashMap<String, Integer>(integers)) : Collections.<String, Integer>emptyMap();
+    Set<Long> _numbers = (numbers != null) ? Collections.unmodifiableSet(new HashSet<Long>(numbers)) : Collections.<Long>emptySet();
+    return new Value(_strings, _integers, _numbers);
   }
 
   public static CollectionFieldsBuilder from(CollectionFields v) {

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -1,18 +1,13 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/FooBuilder.java
+++ b/processor/src/test/resources/expected/FooBuilder.java
@@ -1,18 +1,7 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
@@ -1,18 +1,6 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
@@ -1,16 +1,17 @@
 package foo;
 
+import com.google.common.base.Optional;
 import io.norberg.automatter.AutoMatter;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
 public final class GuavaOptionalFieldsBuilder {
 
-  private com.google.common.base.Optional<String> foo;
-  private com.google.common.base.Optional<String> bar;
+  private Optional<String> foo;
+  private Optional<String> bar;
 
   public GuavaOptionalFieldsBuilder() {
-    this.foo = com.google.common.base.Optional.absent();
+    this.foo = Optional.absent();
   }
 
   private GuavaOptionalFieldsBuilder(GuavaOptionalFields v) {
@@ -23,32 +24,32 @@ public final class GuavaOptionalFieldsBuilder {
     this.bar = v.bar;
   }
 
-  public com.google.common.base.Optional<String> foo() {
+  public Optional<String> foo() {
     return foo;
   }
 
   public GuavaOptionalFieldsBuilder foo(String foo) {
-    return foo(com.google.common.base.Optional.fromNullable(foo));
+    return foo(Optional.fromNullable(foo));
   }
 
-  public GuavaOptionalFieldsBuilder foo(com.google.common.base.Optional<? extends String> foo) {
+  public GuavaOptionalFieldsBuilder foo(Optional<? extends String> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
     }
-    this.foo = (com.google.common.base.Optional<String>) foo;
+    this.foo = (Optional<String>) foo;
     return this;
   }
 
-  public com.google.common.base.Optional<String> bar() {
+  public Optional<String> bar() {
     return bar;
   }
 
   public GuavaOptionalFieldsBuilder bar(String bar) {
-    return bar(com.google.common.base.Optional.fromNullable(bar));
+    return bar(Optional.fromNullable(bar));
   }
 
-  public GuavaOptionalFieldsBuilder bar(com.google.common.base.Optional<? extends String> bar) {
-    this.bar = (com.google.common.base.Optional<String>) bar;
+  public GuavaOptionalFieldsBuilder bar(Optional<? extends String> bar) {
+    this.bar = (Optional<String>) bar;
     return this;
   }
 
@@ -67,11 +68,11 @@ public final class GuavaOptionalFieldsBuilder {
   private static final class Value
       implements GuavaOptionalFields {
 
-    private final com.google.common.base.Optional<String> foo;
-    private final com.google.common.base.Optional<String> bar;
+    private final Optional<String> foo;
+    private final Optional<String> bar;
 
-    private Value(@AutoMatter.Field("foo") com.google.common.base.Optional<String> foo,
-                  @AutoMatter.Field("bar") com.google.common.base.Optional<String> bar) {
+    private Value(@AutoMatter.Field("foo") Optional<String> foo,
+                  @AutoMatter.Field("bar") Optional<String> bar) {
       if (foo == null) {
         throw new NullPointerException("foo");
       }
@@ -81,13 +82,13 @@ public final class GuavaOptionalFieldsBuilder {
 
     @AutoMatter.Field
     @Override
-    public com.google.common.base.Optional<String> foo() {
+    public Optional<String> foo() {
       return foo;
     }
 
     @AutoMatter.Field
     @Override
-    public com.google.common.base.Optional<String> bar() {
+    public Optional<String> bar() {
       return bar;
     }
 

--- a/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
@@ -1,28 +1,17 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
 public final class JUTOptionalFieldsBuilder {
 
-  private java.util.Optional<String> foo;
-  private java.util.Optional<String> bar;
+  private Optional<String> foo;
+  private Optional<String> bar;
 
   public JUTOptionalFieldsBuilder() {
-    this.foo = java.util.Optional.empty();
+    this.foo = Optional.empty();
   }
 
   private JUTOptionalFieldsBuilder(JUTOptionalFields v) {
@@ -35,32 +24,32 @@ public final class JUTOptionalFieldsBuilder {
     this.bar = v.bar;
   }
 
-  public java.util.Optional<String> foo() {
+  public Optional<String> foo() {
     return foo;
   }
 
   public JUTOptionalFieldsBuilder foo(String foo) {
-    return foo(java.util.Optional.ofNullable(foo));
+    return foo(Optional.ofNullable(foo));
   }
 
-  public JUTOptionalFieldsBuilder foo(java.util.Optional<? extends String> foo) {
+  public JUTOptionalFieldsBuilder foo(Optional<? extends String> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
     }
-    this.foo = (java.util.Optional<String>) foo;
+    this.foo = (Optional<String>) foo;
     return this;
   }
 
-  public java.util.Optional<String> bar() {
+  public Optional<String> bar() {
     return bar;
   }
 
   public JUTOptionalFieldsBuilder bar(String bar) {
-    return bar(java.util.Optional.ofNullable(bar));
+    return bar(Optional.ofNullable(bar));
   }
 
-  public JUTOptionalFieldsBuilder bar(java.util.Optional<? extends String> bar) {
-    this.bar = (java.util.Optional<String>) bar;
+  public JUTOptionalFieldsBuilder bar(Optional<? extends String> bar) {
+    this.bar = (Optional<String>) bar;
     return this;
   }
 
@@ -79,11 +68,11 @@ public final class JUTOptionalFieldsBuilder {
   private static final class Value
       implements JUTOptionalFields {
 
-    private final java.util.Optional<String> foo;
-    private final java.util.Optional<String> bar;
+    private final Optional<String> foo;
+    private final Optional<String> bar;
 
-    private Value(@AutoMatter.Field("foo") java.util.Optional<String> foo,
-                  @AutoMatter.Field("bar") java.util.Optional<String> bar) {
+    private Value(@AutoMatter.Field("foo") Optional<String> foo,
+                  @AutoMatter.Field("bar") Optional<String> bar) {
       if (foo == null) {
         throw new NullPointerException("foo");
       }
@@ -93,13 +82,13 @@ public final class JUTOptionalFieldsBuilder {
 
     @AutoMatter.Field
     @Override
-    public java.util.Optional<String> foo() {
+    public Optional<String> foo() {
       return foo;
     }
 
     @AutoMatter.Field
     @Override
-    public java.util.Optional<String> bar() {
+    public Optional<String> bar() {
       return bar;
     }
 

--- a/processor/src/test/resources/expected/NestedFoobarBuilder.java
+++ b/processor/src/test/resources/expected/NestedFoobarBuilder.java
@@ -1,16 +1,3 @@
-import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/NestedPackageLocalFoobarBuilder.java
+++ b/processor/src/test/resources/expected/NestedPackageLocalFoobarBuilder.java
@@ -1,18 +1,5 @@
 package foo;
 
-import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -2,8 +2,12 @@ package foo;
 
 import io.norberg.automatter.AutoMatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -145,8 +149,8 @@ public final class NullableCollectionFieldsBuilder {
   }
 
   public NullableCollectionFieldsBuilder putInteger(String key, Integer value) {
-    if (integers == null) {
-      integers = new HashMap<String,Integer>();
+    if (this.integers == null) {
+      this.integers = new HashMap<String,Integer>();
     }
     integers.put(key, value);
     return this;
@@ -210,9 +214,10 @@ public final class NullableCollectionFieldsBuilder {
   }
 
   public NullableCollectionFields build() {
-    return new Value((strings != null) ? Collections.unmodifiableList(new ArrayList<String>(strings)) : null,
-                     (integers != null) ? Collections.unmodifiableMap(new HashMap<String,Integer>(integers)) : null,
-                     (numbers != null) ? Collections.unmodifiableSet(new HashSet<Long>(numbers)) : null);
+    List<String> _strings = (strings != null) ? Collections.unmodifiableList(new ArrayList<String>(strings)) : null;
+    Map<String, Integer> _integers = (integers != null) ? Collections.unmodifiableMap(new HashMap<String, Integer>(integers)) : null;
+    Set<Long> _numbers = (numbers != null) ? Collections.unmodifiableSet(new HashSet<Long>(numbers)) : null;
+    return new Value(_strings, _integers, _numbers);
   }
 
   public static NullableCollectionFieldsBuilder from(NullableCollectionFields v) {

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -1,18 +1,12 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/NullableFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableFieldsBuilder.java
@@ -1,18 +1,6 @@
 package foo;
 
 import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/PackageLocalBuilder.java
+++ b/processor/src/test/resources/expected/PackageLocalBuilder.java
@@ -1,18 +1,5 @@
 package foo;
 
-import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")

--- a/processor/src/test/resources/expected/TopLevelBuilder.java
+++ b/processor/src/test/resources/expected/TopLevelBuilder.java
@@ -1,16 +1,3 @@
-import io.norberg.automatter.AutoMatter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.annotation.Generated;
 
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")


### PR DESCRIPTION
javapoet is the successor of javawriter by the same authors. Our main advantages of switching over are:
* Fluent API
* Better type support
* Improved import handling (see the diff in the testcases)
* Composing fields/methods/classes instead of emitting code in a single pass.

There are two minor changes in the generated code:
* Field null checks now consistently use `this.field`
* Extracted collection/map fields into local variables in `build()` for clarity

The implementation is still quite close to what we had before but allows for further cleanup more easily, e.g. unifying maps/collection support and splitting the processor into multiple files.