### PR TITLE
fix jackson 2.5.x support

### DIFF
--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.3</version>
     </dependency>
 
     <!--test dependencies-->

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
@@ -1,5 +1,7 @@
 package io.norberg.automatter.jackson;
 
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
@@ -22,5 +24,18 @@ class AutoMatterAnnotationIntrospector extends NopAnnotationIntrospector {
       return member.getName();
     }
     return null;
+  }
+
+  @Override
+  public boolean hasCreatorAnnotation(final Annotated a) {
+    if (!(a instanceof AnnotatedConstructor)) {
+      return false;
+    }
+    final AnnotatedConstructor ctor = (AnnotatedConstructor) a;
+    if (ctor.getParameterCount() == 0) {
+      return true;
+    }
+    final AutoMatter.Field field = ctor.getParameter(0).getAnnotation(AutoMatter.Field.class);
+    return field != null;
   }
 }


### PR DESCRIPTION
jackson 2.5.x calls `AnnotationIntrospector#hasCreatorAnnotation()`
to verify that a constructor should be used in deserialization. This
does not seem to have been done by 2.4.x. As such it looks like a
breaking bug fix change in jackson. The default implementation in
NopAnnotationIntrospector as extended by
AutoMatterAnnotationIntrospector returns false.

To fix this, we implement `#hasCreatorAnnotation()` and have it return
`true` if there's either no fields in the value or the first field is
annotated with `@AutoMatter.Field`.

Also, bump the jackson dependency to 2.5.3.