### PR TITLE
Annotation support

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3</version>
+      <version>2.7</version>
     </dependency>
 
     <!--test dependencies-->

--- a/gson/src/test/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactoryTest.java
@@ -16,6 +16,7 @@ public class AutoMatterTypeAdapterFactoryTest {
   static final Foo FOO = new FooBuilder()
       .a(17)
       .b("foobar")
+      .isPrivate(true)
       .build();
 
   Gson gson;

--- a/gson/src/test/java/io/norberg/automatter/gson/Foo.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/Foo.java
@@ -1,9 +1,12 @@
 package io.norberg.automatter.gson;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.norberg.automatter.AutoMatter;
 
 @AutoMatter
 public interface Foo {
   int a();
   String b();
+  @SerializedName("private") Boolean isPrivate();
 }

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -688,7 +688,10 @@ public final class AutoMatterProcessor extends AbstractProcessor {
         .addSuperinterface(valueType(d));
 
     for (ExecutableElement field : d.fields()) {
-      value.addField(FieldSpec.builder(fieldType(d, field), fieldName(field), PRIVATE, FINAL).build());
+      final FieldSpec.Builder
+          fieldBuilder = FieldSpec.builder(fieldType(d, field), fieldName(field), PRIVATE, FINAL);
+      fieldBuilder.addAnnotations(annotationsFor(field));
+      value.addField(fieldBuilder.build());
     }
 
     value.addMethod(valueConstructor(d));
@@ -702,6 +705,17 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     value.addMethod(valueToString(d));
 
     return value.build();
+  }
+
+  private List<AnnotationSpec> annotationsFor(final ExecutableElement field) {
+    final ArrayList<AnnotationSpec> annotationsSpecs = Lists.newArrayList();
+    for (AnnotationMirror am : field.getAnnotationMirrors()) {
+      //The Nullable annotation gets special treatment as the processor changes behaviour based on
+      if (!am.getAnnotationType().asElement().getSimpleName().contentEquals("Nullable")) {
+        annotationsSpecs.add(AnnotationSpec.get(am));
+      }
+    }
+    return annotationsSpecs;
   }
 
   private MethodSpec valueConstructor(final Descriptor d) throws AutoMatterProcessorException {

--- a/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
+++ b/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
@@ -256,6 +256,16 @@ public class AutoMatterProcessorTest {
         .and().generatesSources(JavaFileObjects.forResource("expected/inheritance/GenericFoobarBuilder.java"));
   }
 
+  @Test
+  public void testAnnotationsPassedOn() {
+    final JavaFileObject source = JavaFileObjects.forResource("good/AnnotatedField.java");
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(new AutoMatterProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(JavaFileObjects.forResource("expected/AnnotatedFieldBuilder.java"));
+  }
+
   private boolean isJava8() {
     try {
       Class.forName("java.util.Optional");

--- a/processor/src/test/resources/expected/AnnotatedFieldBuilder.java
+++ b/processor/src/test/resources/expected/AnnotatedFieldBuilder.java
@@ -1,0 +1,93 @@
+package foo;
+
+import io.norberg.automatter.AutoMatter;
+import javax.annotation.Generated;
+import javax.annotation.Resource;
+
+@Generated("io.norberg.automatter.processor.AutoMatterProcessor")
+public final class AnnotatedFieldBuilder {
+  private boolean isPrivate;
+
+  public AnnotatedFieldBuilder() {
+  }
+
+  private AnnotatedFieldBuilder(AnnotatedField v) {
+    this.isPrivate = v.isPrivate();
+  }
+
+  private AnnotatedFieldBuilder(AnnotatedFieldBuilder v) {
+    this.isPrivate = v.isPrivate;
+  }
+
+  public boolean isPrivate() {
+    return isPrivate;
+  }
+
+  public AnnotatedFieldBuilder isPrivate(boolean isPrivate) {
+    this.isPrivate = isPrivate;
+    return this;
+  }
+
+  public AnnotatedField build() {
+    return new Value(isPrivate);
+  }
+
+  public static AnnotatedFieldBuilder from(AnnotatedField v) {
+    return new AnnotatedFieldBuilder(v);
+  }
+
+  public static AnnotatedFieldBuilder from(AnnotatedFieldBuilder v) {
+    return new AnnotatedFieldBuilder(v);
+  }
+
+  private static final class Value implements AnnotatedField {
+    @Resource(
+        name = "private"
+    )
+    private final boolean isPrivate;
+
+    private Value(@AutoMatter.Field("isPrivate") boolean isPrivate) {
+      this.isPrivate = isPrivate;
+    }
+
+    @AutoMatter.Field
+    @Override
+    public boolean isPrivate() {
+      return isPrivate;
+    }
+
+    public AnnotatedFieldBuilder builder() {
+      return new AnnotatedFieldBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof AnnotatedField)) {
+        return false;
+      }
+      final AnnotatedField that = (AnnotatedField) o;
+      if (isPrivate != that.isPrivate()) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      long temp;
+      result = 31 * result + (isPrivate ? 1231 : 1237);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "AnnotatedField{" +
+             "isPrivate=" + isPrivate +
+             '}';
+    }
+  }
+}

--- a/processor/src/test/resources/good/AnnotatedField.java
+++ b/processor/src/test/resources/good/AnnotatedField.java
@@ -1,0 +1,12 @@
+package foo;
+
+import javax.annotation.Resource;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface AnnotatedField {
+
+  @Resource(name="private")
+  boolean isPrivate();
+}


### PR DESCRIPTION
Add support for passing annotations on methods to fields.
This makes it possible to annotate automatter interfaces used in
for example gson and jackson with serialization properties.

Fixes #37