### PR TITLE
Serialized name for gson

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3</version>
+      <version>2.7</version>
     </dependency>
 
     <!--test dependencies-->

--- a/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapter.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapter.java
@@ -1,0 +1,102 @@
+package io.norberg.automatter.gson;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class AutoMatterTypeAdapter<T> extends TypeAdapter<T> {
+
+  private final TypeAdapter<JsonElement> elementAdapter;
+  private final ImmutableMap<String, List<String>> serializedNameMethods;
+  private final Gson gson;
+  private final TypeAdapter<T> delegate;
+
+
+  public static <T> AutoMatterTypeAdapter<T> createForInterface(
+      final Gson gson,
+      final Class<T> cls,
+      final ImmutableMap<String, List<String>> serializedNameMethods
+  ) {
+    return new AutoMatterTypeAdapter<>(gson, gson.getAdapter(cls), serializedNameMethods);
+  }
+
+  public static <T> AutoMatterTypeAdapter<T> createForValue(
+      final Gson gson,
+      final TypeAdapterFactory skipFactory,
+      final TypeToken<T> type,
+      final ImmutableMap<String, List<String>> serializedNameMethods
+  ) {
+    return new AutoMatterTypeAdapter<>(gson,
+                                       gson.getDelegateAdapter(skipFactory, type),
+                                       serializedNameMethods);
+  }
+
+  private AutoMatterTypeAdapter(final Gson gson,
+                                final TypeAdapter<T> delegate,
+                                final ImmutableMap<String, List<String>> serializedNameMethods) {
+    this.gson = gson;
+    this.delegate = delegate;
+    this.serializedNameMethods = serializedNameMethods;
+    elementAdapter = gson.getAdapter(JsonElement.class);
+  }
+
+  private String translateField(final String fieldName) {
+    return StringFieldNamingPolicy.valueOf(gson.fieldNamingStrategy().toString())
+        .translateName(fieldName);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void write(final JsonWriter out, final T value) throws IOException {
+    final JsonElement tree = delegate.toJsonTree(value);
+    if (tree.isJsonObject()) {
+      for (Map.Entry<String, List<String>> entry : serializedNameMethods.entrySet()) {
+        final String fieldName = translateField(entry.getKey());
+        final List<String> alternatives = entry.getValue();
+        final JsonObject asJsonObject = tree.getAsJsonObject();
+        final JsonElement element = asJsonObject.get(fieldName);
+        if (element != null) {
+          asJsonObject.remove(fieldName);
+          asJsonObject.add(alternatives.get(0), element);
+        }
+      }
+    }
+    elementAdapter.write(out, tree);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T read(final JsonReader in) throws IOException {
+    final JsonElement tree = elementAdapter.read(in);
+    if (tree.isJsonObject()) {
+      for (Map.Entry<String, List<String>> entry : serializedNameMethods.entrySet()) {
+        final String fieldName = translateField(entry.getKey());
+        final List<String> alternatives = entry.getValue();
+        final JsonObject asJsonObject = tree.getAsJsonObject();
+        for (String alternative : alternatives) {
+          final JsonElement element = asJsonObject.get(alternative);
+          if (element != null) {
+            asJsonObject.remove(alternative);
+            asJsonObject.add(fieldName, element);
+            break;
+          }
+        }
+      }
+    }
+    return delegate.fromJsonTree(tree);
+  }
+}

--- a/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapter.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapter.java
@@ -18,7 +18,6 @@ public class AutoMatterTypeAdapter<T> extends TypeAdapter<T> {
 
   private final TypeAdapter<JsonElement> elementAdapter;
   private final ImmutableMap<String, List<String>> serializedNameMethods;
-  private final Gson gson;
   private final TypeAdapter<T> delegate;
 
 
@@ -44,16 +43,11 @@ public class AutoMatterTypeAdapter<T> extends TypeAdapter<T> {
   private AutoMatterTypeAdapter(final Gson gson,
                                 final TypeAdapter<T> delegate,
                                 final ImmutableMap<String, List<String>> serializedNameMethods) {
-    this.gson = gson;
     this.delegate = delegate;
     this.serializedNameMethods = serializedNameMethods;
     elementAdapter = gson.getAdapter(JsonElement.class);
   }
 
-  private String translateField(final String fieldName) {
-    return StringFieldNamingPolicy.valueOf(gson.fieldNamingStrategy().toString())
-        .translateName(fieldName);
-  }
 
   /**
    * {@inheritDoc}
@@ -63,7 +57,7 @@ public class AutoMatterTypeAdapter<T> extends TypeAdapter<T> {
     final JsonElement tree = delegate.toJsonTree(value);
     if (tree.isJsonObject()) {
       for (Map.Entry<String, List<String>> entry : serializedNameMethods.entrySet()) {
-        final String fieldName = translateField(entry.getKey());
+        final String fieldName = entry.getKey();
         final List<String> alternatives = entry.getValue();
         final JsonObject asJsonObject = tree.getAsJsonObject();
         final JsonElement element = asJsonObject.get(fieldName);
@@ -84,7 +78,7 @@ public class AutoMatterTypeAdapter<T> extends TypeAdapter<T> {
     final JsonElement tree = elementAdapter.read(in);
     if (tree.isJsonObject()) {
       for (Map.Entry<String, List<String>> entry : serializedNameMethods.entrySet()) {
-        final String fieldName = translateField(entry.getKey());
+        final String fieldName = entry.getKey();
         final List<String> alternatives = entry.getValue();
         final JsonObject asJsonObject = tree.getAsJsonObject();
         for (String alternative : alternatives) {

--- a/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactory.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactory.java
@@ -43,8 +43,20 @@ public class AutoMatterTypeAdapterFactory implements TypeAdapterFactory {
 
       // Look up and instantiate the value class
       final String name = type.getRawType().getName();
-      final String valueName = name + VALUE_SUFFIX;
+      final int lastDollar = name.lastIndexOf("$");
+
+      final String valueName;
+      if (lastDollar > -1) {
+        final int lastDot = name.lastIndexOf(".");
+        valueName =
+            name.substring(0, lastDot + 1).concat(name.substring(lastDollar + 1)) + VALUE_SUFFIX;
+
+      } else {
+        valueName = name + VALUE_SUFFIX;
+      }
+
       final Class<T> cls;
+
       try {
         cls = (Class<T>) Class.forName(valueName);
       } catch (ClassNotFoundException e) {

--- a/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactory.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactory.java
@@ -1,14 +1,23 @@
 package io.norberg.automatter.gson;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import io.norberg.automatter.AutoMatter;
+
+import static io.norberg.automatter.gson.AutoMatterTypeAdapter.createForInterface;
+import static io.norberg.automatter.gson.AutoMatterTypeAdapter.createForValue;
+import static java.util.Arrays.asList;
 
 public class AutoMatterTypeAdapterFactory implements TypeAdapterFactory {
 
@@ -19,32 +28,89 @@ public class AutoMatterTypeAdapterFactory implements TypeAdapterFactory {
   @SuppressWarnings("unchecked")
   @Override
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    final TypeAdapter<T> materialized;
     final AutoMatter annotation = type.getRawType().getAnnotation(AutoMatter.class);
-    if (annotation == null) {
-      // This was not an @AutoMatter type.
-      return null;
+
+    if (annotation != null) {
+      // We are now the proud owners of an AutoMatter annotated interface.
+
+      // Return the cached type, if present.
+      final TypeAdapter cached = adapters.get(type);
+      if (cached != null) {
+        return cached;
+      }
+
+      // Look up and instantiate the value class
+      final String name = type.getRawType().getName();
+      final String valueName = name + VALUE_SUFFIX;
+      final Class<T> cls;
+      try {
+        cls = (Class<T>) Class.forName(valueName);
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException("No builder found for @AutoMatter type: " + name, e);
+      }
+
+      // Find those magic remapping-of-name-annotations (SerializedName)
+      final ImmutableMap<String, List<String>>
+          serializedNameMethods = getSerializedNameMethods(type.getRawType());
+
+      // If the interface passed to us didn't have any SerializedName annotations, go the fast path
+      // and just pass it on the type adapter chain,
+      // it will most likely end up in the ReflectiveTypeAdapterFactory, good riddance!
+      // If it was annotated, we create a TypeAdapter that knows how to poke the json into
+      // Java world submission.
+      materialized = serializedNameMethods.isEmpty()
+                     ? gson.getAdapter(cls)
+                     : createForInterface(gson, cls, serializedNameMethods);
+    } else {
+      // Maybe a value class with SerializedName annotations?
+
+      final ImmutableMap.Builder<String, List<String>>
+          serializedNameMethodsbuilder = ImmutableMap.builder();
+
+      // Since AutoMatter supports inheritance we need to walk through all of the interfaces with
+      // AutoMatter annotations.
+      for (Class<?> itf : type.getRawType().getInterfaces()) {
+        if (itf.getAnnotation(AutoMatter.class) != null) {
+          serializedNameMethodsbuilder.putAll(getSerializedNameMethods(itf));
+        }
+      }
+
+      final ImmutableMap<String, List<String>>
+          serializedNameMethods = serializedNameMethodsbuilder.build();
+
+      // Either what we were passed wasn't a value class or it was not annotated with SerializedName
+      // either way, we don't have to care, pass it on to the chain of factories that might be
+      // applicable. Bye, bye! This should be the fast path.
+      if (serializedNameMethods.isEmpty()) {
+        return null;
+      }
+      // We create a TypeAdapter that knows how to read between the lines (A.K.A is annotation aware)
+      // and can translate the restricted Java world names to beautiful free form json fields. Nom!
+      materialized = createForValue(gson, this, type, serializedNameMethods);
     }
-
-    // Return the cached type, if present.
-    final TypeAdapter cached = adapters.get(type);
-    if (cached != null) {
-      return cached;
-    }
-
-    // Look up and instantiate the value class
-    final String name = type.getRawType().getName();
-    final String valueName = name + VALUE_SUFFIX;
-    final Class<T> cls;
-    try {
-      cls = (Class<T>) Class.forName(valueName);
-    } catch (ClassNotFoundException e) {
-      throw new IllegalArgumentException("No builder found for @AutoMatter type: " + name, e);
-    }
-
-    final TypeAdapter<T> materialized = gson.getAdapter(cls);
-
     // Cache the materialized type before returning
     final TypeAdapter<T> existing = adapters.putIfAbsent(type, materialized);
     return (existing != null) ? existing : materialized;
   }
+
+  private <T> ImmutableMap<String, List<String>> getSerializedNameMethods(Class<T> c) {
+    final ImmutableMap.Builder<String, List<String>>
+        methodToAnnotation = ImmutableMap.builder();
+
+    for (Method method : c.getMethods()) {
+      if (method.isAnnotationPresent(SerializedName.class)) {
+        final SerializedName serializedName = method.getAnnotation(SerializedName.class);
+        methodToAnnotation.put(method.getName(),
+                               ImmutableList.<String>builder()
+                                   .add(serializedName.value())
+                                   .addAll(asList(serializedName.alternate()))
+                                   .build());
+      }
+
+    }
+
+    return methodToAnnotation.build();
+  }
+
 }

--- a/gson/src/main/java/io/norberg/automatter/gson/StringFieldNamingPolicy.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/StringFieldNamingPolicy.java
@@ -1,0 +1,173 @@
+/*
+* Copyright (C) 2008 Google Inc.
+* Copyright (C) 2016 Olle Lundberg.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package io.norberg.automatter.gson;
+
+import java.util.Locale;
+
+/**
+ * An enumeration that defines a few standard naming conventions for JSON field names.
+ * This enumeration is a reimplementation of the FieldNamingPolicy shipped with Gson, but
+ * adapted to work on strings instead of fields.
+ *
+ * @author Inderjeet Singh
+ * @author Joel Leitch
+ * @author Olle Lundberg
+ */
+public enum StringFieldNamingPolicy implements StringFieldNamingStrategy {
+
+  /**
+   * Using this naming policy with Gson will ensure that the field name is
+   * unchanged.
+   */
+  IDENTITY() {
+    @Override
+    public String translateName(String f) {
+      return f;
+    }
+  },
+
+  /**
+   * Using this naming policy will ensure that the first "letter" of the string
+   * is capitalized when translated.
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   * <li>someFieldName ---> SomeFieldName</li>
+   * <li>_someFieldName ---> _SomeFieldName</li>
+   * </ul>
+   */
+  UPPER_CAMEL_CASE() {
+    @Override
+    public String translateName(String f) {
+      return upperCaseFirstLetter(f);
+    }
+  },
+
+  /**
+   * Using this naming policy will ensure that the first "letter" of the string
+   * is capitalized when translated and the words will be separated by a space.
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   * <li>someFieldName ---> Some Field Name</li>
+   * <li>_someFieldName ---> _Some Field Name</li>
+   * </ul>
+   *
+   */
+  UPPER_CAMEL_CASE_WITH_SPACES() {
+    @Override
+    public String translateName(String f) {
+      return upperCaseFirstLetter(separateCamelCase(f, " "));
+    }
+  },
+
+  /**
+   * Using this naming policy will modify the string from its camel cased
+   * form to a lower case string where each word is separated by an underscore (_).
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   * <li>someFieldName ---> some_field_name</li>
+   * <li>_someFieldName ---> _some_field_name</li>
+   * <li>aStringField ---> a_string_field</li>
+   * <li>aURL ---> a_u_r_l</li>
+   * </ul>
+   */
+  LOWER_CASE_WITH_UNDERSCORES() {
+    @Override
+    public String translateName(String f) {
+      return separateCamelCase(f, "_").toLowerCase(Locale.ENGLISH);
+    }
+  },
+
+  /**
+   * Using this naming policy will modify the string from its camel cased
+   * form to a lower case string where each word is separated by a dash (-).
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   * <li>someFieldName ---> some-field-name</li>
+   * <li>_someFieldName ---> _some-field-name</li>
+   * <li>aStringField ---> a-string-field</li>
+   * <li>aURL ---> a-u-r-l</li>
+   * </ul>
+   * Using dashes in JavaScript is not recommended since dash is also used for a minus sign in
+   * expressions. This requires that a field named with dashes is always accessed as a quoted
+   * property like {@code myobject['my-field']}. Accessing it as an object field
+   * {@code myobject.my-field} will result in an unintended javascript expression.
+   *
+   */
+  LOWER_CASE_WITH_DASHES() {
+    @Override
+    public String translateName(String f) {
+      return separateCamelCase(f, "-").toLowerCase(Locale.ENGLISH);
+    }
+  };
+
+  /**
+   * Converts the string that uses camel-case define word separation into
+   * separate words that are separated by the provided {@code separatorString}.
+   */
+  static String separateCamelCase(String name, String separator) {
+    StringBuilder translation = new StringBuilder();
+    for (int i = 0; i < name.length(); i++) {
+      char character = name.charAt(i);
+      if (Character.isUpperCase(character) && translation.length() != 0) {
+        translation.append(separator);
+      }
+      translation.append(character);
+    }
+    return translation.toString();
+  }
+
+  /**
+   * Ensures the JSON field names begins with an upper case letter.
+   */
+  static String upperCaseFirstLetter(String name) {
+    StringBuilder fieldNameBuilder = new StringBuilder();
+    int index = 0;
+    char firstCharacter = name.charAt(index);
+
+    while (index < name.length() - 1) {
+      if (Character.isLetter(firstCharacter)) {
+        break;
+      }
+
+      fieldNameBuilder.append(firstCharacter);
+      firstCharacter = name.charAt(++index);
+    }
+
+    if (index == name.length()) {
+      return fieldNameBuilder.toString();
+    }
+
+    if (!Character.isUpperCase(firstCharacter)) {
+      String modifiedTarget = modifyString(Character.toUpperCase(firstCharacter), name, ++index);
+      return fieldNameBuilder.append(modifiedTarget).toString();
+    } else {
+      return name;
+    }
+  }
+
+  private static String modifyString(char firstCharacter, String srcString, int indexOfSubstring) {
+    return (indexOfSubstring < srcString.length())
+           ? firstCharacter + srcString.substring(indexOfSubstring)
+           : String.valueOf(firstCharacter);
+  }
+}
+

--- a/gson/src/main/java/io/norberg/automatter/gson/StringFieldNamingStrategy.java
+++ b/gson/src/main/java/io/norberg/automatter/gson/StringFieldNamingStrategy.java
@@ -1,0 +1,22 @@
+package io.norberg.automatter.gson;
+
+
+/**
+ * A mechanism for providing custom field naming in Gson adapted for strings
+ * This allows the client code to translate field names into a particular convention
+ * that is not supported as a normal Java field declaration rules.
+ * For example, Java does not support"-"characters in a field name.
+ *
+ * @author Olle Lundberg
+ */
+
+public interface StringFieldNamingStrategy {
+
+  /**
+   * Translates the string into its JSON field name representation.
+   *
+   * @param f the string object that we are translating
+   * @return the translated string.
+   */
+  public String translateName(String f);
+}

--- a/gson/src/test/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/AutoMatterTypeAdapterFactoryTest.java
@@ -26,6 +26,8 @@ public class AutoMatterTypeAdapterFactoryTest {
       .isPrivate(true)
       .build();
 
+  private NestedGson nestedGson;
+
   Gson gson;
 
   @Before
@@ -33,6 +35,7 @@ public class AutoMatterTypeAdapterFactoryTest {
     gson = new GsonBuilder()
         .registerTypeAdapterFactory(new AutoMatterTypeAdapterFactory())
         .create();
+    nestedGson = new NestedGsonBuilder().cutee(new NesteeBuilder().floof("foobar").build()).build();
   }
 
   @Test
@@ -60,5 +63,11 @@ public class AutoMatterTypeAdapterFactoryTest {
     //Make sure that tranlation of under_scored fields still work.
     final String underscoredIsPrivate = "{\"a\":17,\"b\":\"foobar\",\"is_private\":true}";
     assertThat(gson.fromJson(underscoredIsPrivate, Bar.class), is(BAR)); //is_private -> isPrivate
+  }
+
+  @Test
+  public void testNesting() throws IOException {
+    final String json = gson.toJson(nestedGson);
+    assertThat(gson.fromJson(json, NestedGson.class), is(nestedGson));
   }
 }

--- a/gson/src/test/java/io/norberg/automatter/gson/Bar.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/Bar.java
@@ -1,0 +1,12 @@
+package io.norberg.automatter.gson;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface Bar {
+  int a();
+  String b();
+  @SerializedName("private") boolean isPrivate();
+}

--- a/gson/src/test/java/io/norberg/automatter/gson/Foo.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/Foo.java
@@ -4,6 +4,8 @@ import io.norberg.automatter.AutoMatter;
 
 @AutoMatter
 public interface Foo {
+
   int a();
+
   String b();
 }

--- a/gson/src/test/java/io/norberg/automatter/gson/NestedGson.java
+++ b/gson/src/test/java/io/norberg/automatter/gson/NestedGson.java
@@ -1,0 +1,14 @@
+package io.norberg.automatter.gson;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface NestedGson {
+
+  Nestee cutee();
+
+  @AutoMatter interface Nestee {
+    String floof();
+  }
+
+}


### PR DESCRIPTION
This is another approach to add support for SerializedName annotation in Gson. It's less intrusive than #38, but likely less performant.

Fixes #37.