### PR TITLE
Suppress compile time java warnings in generated code

### DIFF
--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -433,10 +433,21 @@ public final class AutoMatterProcessor extends AbstractProcessor {
         .varargs()
         .returns(builderType(d));
 
+    ensureSafeVarargs(setter);
+
     collectionNullGuard(setter, field);
 
     setter.addStatement("return $N($T.asList($N))", fieldName, ClassName.get(Arrays.class), fieldName);
     return setter.build();
+  }
+
+  private void ensureSafeVarargs(MethodSpec.Builder setter) {
+    // TODO: Add SafeVarargs annotation only for non-reifiable types.
+    AnnotationSpec safeVarargsAnnotation = AnnotationSpec.builder(SafeVarargs.class).build();
+
+    setter
+        .addAnnotation(safeVarargsAnnotation)
+        .addModifiers(FINAL); // Only because SafeVarargs can be applied to final methods.
   }
 
   private MethodSpec collectionAdder(final Descriptor d, final ExecutableElement field) {

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -88,7 +88,8 @@ public final class CollectionFieldsBuilder {
     return this;
   }
 
-  public CollectionFieldsBuilder strings(String... strings) {
+  @SafeVarargs
+  public final CollectionFieldsBuilder strings(String... strings) {
     if (strings == null) {
       throw new NullPointerException("strings");
     }
@@ -262,7 +263,8 @@ public final class CollectionFieldsBuilder {
     return this;
   }
 
-  public CollectionFieldsBuilder numbers(Long... numbers) {
+  @SafeVarargs
+  public final CollectionFieldsBuilder numbers(Long... numbers) {
     if (numbers == null) {
       throw new NullPointerException("numbers");
     }

--- a/processor/src/test/resources/expected/GenericCollectionBuilder.java
+++ b/processor/src/test/resources/expected/GenericCollectionBuilder.java
@@ -81,7 +81,8 @@ public final class GenericCollectionBuilder<T, K, V> {
     return this;
   }
 
-  public GenericCollectionBuilder<T, K, V> foos(T... foos) {
+  @SafeVarargs
+  public final GenericCollectionBuilder<T, K, V> foos(T... foos) {
     if (foos == null) {
       throw new NullPointerException("foos");
     }

--- a/processor/src/test/resources/expected/GenericGuavaOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GenericGuavaOptionalFieldsBuilder.java
@@ -17,13 +17,17 @@ public final class GenericGuavaOptionalFieldsBuilder<T> {
   }
 
   private GenericGuavaOptionalFieldsBuilder(GenericGuavaOptionalFields<? extends T> v) {
-    this.foo = (Optional<T>) v.foo();
-    this.bar = (Optional<T>) v.bar();
+    @SuppressWarnings("unchecked") Optional<T> _foo = (Optional<T>) v.foo();
+    this.foo = _foo;
+    @SuppressWarnings("unchecked") Optional<T> _bar = (Optional<T>) v.bar();
+    this.bar = _bar;
   }
 
   private GenericGuavaOptionalFieldsBuilder(GenericGuavaOptionalFieldsBuilder<? extends T> v) {
-    this.foo = (Optional<T>) v.foo;
-    this.bar = (Optional<T>) v.bar;
+    @SuppressWarnings("unchecked") Optional<T> _foo = (Optional<T>) v.foo();
+    this.foo = _foo;
+    @SuppressWarnings("unchecked") Optional<T> _bar = (Optional<T>) v.bar();
+    this.bar = _bar;
   }
 
   public Optional<T> foo() {
@@ -34,6 +38,7 @@ public final class GenericGuavaOptionalFieldsBuilder<T> {
     return foo(Optional.fromNullable(foo));
   }
 
+  @SuppressWarnings("unchecked")
   public GenericGuavaOptionalFieldsBuilder<T> foo(Optional<? extends T> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
@@ -50,6 +55,7 @@ public final class GenericGuavaOptionalFieldsBuilder<T> {
     return bar(Optional.fromNullable(bar));
   }
 
+  @SuppressWarnings("unchecked")
   public GenericGuavaOptionalFieldsBuilder<T> bar(Optional<? extends T> bar) {
     this.bar = (Optional<T>) bar;
     return this;

--- a/processor/src/test/resources/expected/GenericJUTOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GenericJUTOptionalFieldsBuilder.java
@@ -17,13 +17,17 @@ public final class GenericJUTOptionalFieldsBuilder<T> {
   }
 
   private GenericJUTOptionalFieldsBuilder(GenericJUTOptionalFields<? extends T> v) {
-    this.foo = (Optional<T>) v.foo();
-    this.bar = (Optional<T>) v.bar();
+    @SuppressWarnings("unchecked") Optional<T> _foo = (Optional<T>) v.foo();
+    this.foo = _foo;
+    @SuppressWarnings("unchecked") Optional<T> _bar = (Optional<T>) v.bar();
+    this.bar = _bar;
   }
 
   private GenericJUTOptionalFieldsBuilder(GenericJUTOptionalFieldsBuilder<? extends T> v) {
-    this.foo = (Optional<T>) v.foo;
-    this.bar = (Optional<T>) v.bar;
+    @SuppressWarnings("unchecked") Optional<T> _foo = (Optional<T>) v.foo();
+    this.foo = _foo;
+    @SuppressWarnings("unchecked") Optional<T> _bar = (Optional<T>) v.bar();
+    this.bar = _bar;
   }
 
   public Optional<T> foo() {
@@ -34,6 +38,7 @@ public final class GenericJUTOptionalFieldsBuilder<T> {
     return foo(Optional.ofNullable(foo));
   }
 
+  @SuppressWarnings("unchecked")
   public GenericJUTOptionalFieldsBuilder<T> foo(Optional<? extends T> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
@@ -50,6 +55,7 @@ public final class GenericJUTOptionalFieldsBuilder<T> {
     return bar(Optional.ofNullable(bar));
   }
 
+  @SuppressWarnings("unchecked")
   public GenericJUTOptionalFieldsBuilder<T> bar(Optional<? extends T> bar) {
     this.bar = (Optional<T>) bar;
     return this;

--- a/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/GuavaOptionalFieldsBuilder.java
@@ -32,6 +32,7 @@ public final class GuavaOptionalFieldsBuilder {
     return foo(Optional.fromNullable(foo));
   }
 
+  @SuppressWarnings("unchecked")
   public GuavaOptionalFieldsBuilder foo(Optional<? extends String> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
@@ -48,6 +49,7 @@ public final class GuavaOptionalFieldsBuilder {
     return bar(Optional.fromNullable(bar));
   }
 
+  @SuppressWarnings("unchecked")
   public GuavaOptionalFieldsBuilder bar(Optional<? extends String> bar) {
     this.bar = (Optional<String>) bar;
     return this;

--- a/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
+++ b/processor/src/test/resources/expected/JUTOptionalFieldsBuilder.java
@@ -32,6 +32,7 @@ public final class JUTOptionalFieldsBuilder {
     return foo(Optional.ofNullable(foo));
   }
 
+  @SuppressWarnings("unchecked")
   public JUTOptionalFieldsBuilder foo(Optional<? extends String> foo) {
     if (foo == null) {
       throw new NullPointerException("foo");
@@ -48,6 +49,7 @@ public final class JUTOptionalFieldsBuilder {
     return bar(Optional.ofNullable(bar));
   }
 
+  @SuppressWarnings("unchecked")
   public JUTOptionalFieldsBuilder bar(Optional<? extends String> bar) {
     this.bar = (Optional<String>) bar;
     return this;

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -79,7 +79,8 @@ public final class NullableCollectionFieldsBuilder {
     return this;
   }
 
-  public NullableCollectionFieldsBuilder strings(String... strings) {
+  @SafeVarargs
+  public final NullableCollectionFieldsBuilder strings(String... strings) {
     if (strings == null) {
       this.strings = null;
       return this;
@@ -197,7 +198,8 @@ public final class NullableCollectionFieldsBuilder {
     return this;
   }
 
-  public NullableCollectionFieldsBuilder numbers(Long... numbers) {
+  @SafeVarargs
+  public final NullableCollectionFieldsBuilder numbers(Long... numbers) {
     if (numbers == null) {
       this.numbers = null;
       return this;


### PR DESCRIPTION
When compiling projects with for example `-Xlint:all` option generated sources will issue warnings like:
```
[WARNING] /Users/martinskalvans/proj/auto-matter/example/target/generated-sources/annotations/io/norberg/automatter/example/ComplexGenericFoobarBuilder.java:[121,36] unchecked cast
  required: com.google.common.base.Optional<FOO>
  found:    com.google.common.base.Optional<capture#3 of ? extends FOO>
[WARNING] /Users/martinskalvans/proj/auto-matter/example/target/generated-sources/annotations/io/norberg/automatter/example/ComplexGenericFoobarBuilder.java:[174,75] Possible heap pollution from parameterized vararg type BAR
```
In these cases warning is false alert and can be suppressed.
This will help developers focus on actual problems and not hun down non-auto-matter related messages.