### PR TITLE
Ignore default methods that are also present on superinterfaces

### DIFF
--- a/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
@@ -7,6 +7,7 @@ import com.squareup.javapoet.TypeVariableName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -104,22 +105,21 @@ class Descriptor {
   }
 
   private List<ExecutableElement> methods(final TypeElement element) {
-    final List<ExecutableElement> methods = new ArrayList<>();
-    enumerateMethods(element, methods);
-    return methods;
+    final Map<String, ExecutableElement> methodMap = new LinkedHashMap<>();
+    enumerateMethods(element, methodMap);
+    return new ArrayList<>(methodMap.values());
   }
 
-  private void enumerateMethods(final TypeElement element, final List<ExecutableElement> methods) {
+  private void enumerateMethods(final TypeElement element, final Map<String, ExecutableElement> methods) {
     for (final TypeMirror interfaceType : element.getInterfaces()) {
       final TypeElement interfaceElement = (TypeElement) ((DeclaredType) interfaceType).asElement();
       enumerateMethods(interfaceElement, methods);
     }
     for (final Element member : element.getEnclosedElements()) {
-      if (member.getKind() != ElementKind.METHOD ||
-          isStaticOrDefault(member)) {
+      if (member.getKind() != ElementKind.METHOD) {
         continue;
       }
-      methods.add((ExecutableElement) member);
+      methods.put(member.getSimpleName().toString(), (ExecutableElement) member);
     }
   }
 

--- a/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
+++ b/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
@@ -180,6 +180,17 @@ public class AutoMatterProcessorTest {
   }
 
   @Test
+  public void testOverriddenDefaultMethods() {
+    Assume.assumeTrue(isJava8());
+    assert_().about(javaSource())
+        .that(JavaFileObjects.forResource("good/OverriddenBaseMethods.java"))
+        .processedWith(new AutoMatterProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(
+        JavaFileObjects.forResource("expected/OverriddenMethodsBuilder.java"));
+  }
+
+  @Test
   public void testGenericSingle() {
     final JavaFileObject source = JavaFileObjects.forResource("good/GenericSingle.java");
     assert_().about(javaSource())

--- a/processor/src/test/resources/expected/OverriddenMethodsBuilder.java
+++ b/processor/src/test/resources/expected/OverriddenMethodsBuilder.java
@@ -1,0 +1,101 @@
+package foo;
+
+import io.norberg.automatter.AutoMatter;
+import javax.annotation.Generated;
+
+@Generated("io.norberg.automatter.processor.AutoMatterProcessor")
+public final class OverriddenBaseMethodsBuilder {
+
+  private String baz;
+
+  public OverriddenBaseMethodsBuilder() {
+  }
+
+  private OverriddenBaseMethodsBuilder(OverriddenBaseMethods v) {
+    this.baz = v.baz();
+  }
+
+  private OverriddenBaseMethodsBuilder(OverriddenBaseMethodsBuilder v) {
+    this.baz = v.baz;
+  }
+
+  public String baz() {
+    return baz;
+  }
+
+  public OverriddenBaseMethodsBuilder baz(String baz) {
+    if (baz == null) {
+      throw new NullPointerException("baz");
+    }
+    this.baz = baz;
+    return this;
+  }
+
+  public OverriddenBaseMethods build() {
+    return new Value(baz);
+  }
+
+  public static OverriddenBaseMethodsBuilder from(OverriddenBaseMethods v) {
+    return new OverriddenBaseMethodsBuilder(v);
+  }
+
+  public static OverriddenBaseMethodsBuilder from(OverriddenBaseMethodsBuilder v) {
+    return new OverriddenBaseMethodsBuilder(v);
+  }
+
+  private static final class Value implements OverriddenBaseMethods {
+
+    private final String baz;
+
+    private Value(@AutoMatter.Field("baz") String baz) {
+      if (baz == null) {
+        throw new NullPointerException("baz");
+      }
+      this.baz = baz;
+    }
+
+    @AutoMatter.Field
+    @Override
+    public String baz() {
+      return baz;
+    }
+
+    public OverriddenBaseMethodsBuilder builder() {
+      return new OverriddenBaseMethodsBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof OverriddenBaseMethods)) {
+        return false;
+      }
+
+      final OverriddenBaseMethods that = (OverriddenBaseMethods) o;
+
+      if (baz != null ? !baz.equals(that.baz()) : that.baz() != null) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      long temp;
+
+      result = 31 * result + (baz != null ? baz.hashCode() : 0);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "OverriddenBaseMethods{" +
+             "baz=" + baz +
+             '}';
+    }
+  }
+}

--- a/processor/src/test/resources/good/OverriddenBaseMethods.java
+++ b/processor/src/test/resources/good/OverriddenBaseMethods.java
@@ -1,0 +1,16 @@
+package foo;
+
+import io.norberg.automatter.AutoMatter;
+
+interface Base {
+  String foo();
+}
+
+@AutoMatter
+public interface OverriddenBaseMethods extends Base {
+  default String foo() {
+    return "";
+  }
+
+  String baz();
+}


### PR DESCRIPTION
Currently if you have a default method on an AutoMatter annotated
interface Foo that is also present in Bar (and Foo extends Bar)
AutoMatter will treat the method as a field. The motivation for that
setup is for when you want the generated values to implement some
interface.

This patch solves the issue by enumerating methods into a map so that
any default methods defined in the interface will take precedence over
what's present in the superinterfaces.

A `LinkedHashMap` is used to preserve insertion order.