### PR TITLE
customizable toString

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ jobs:
     install: jdk_switcher use oraclejdk8
     after_success:
       - mvn -pl rut clean cobertura:cobertura coveralls:report -Dcoveralls.token=${COVERALLS_TOKEN}
-  - env: JDK=10
-    install: source install-jdk.sh -F 10 -L BCL
   - env: JDK=11
     install: source install-jdk.sh -F 11 -L BCL
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,43 @@ Baz baz = new BazBuilder()
     .build();
 ```
 
+### Customizing `toString`
+
+The AutoMatter-generated `toString` method can be overriden by annotating a method with `@AutoMatter.ToString`.
+
+This method can be either a `default` method:
+
+```java
+@AutoMatter
+interface Foobar {
+  String foo();
+  int bar();
+
+  @AutoMatter.ToString
+  default String overrideToString() {
+    return foo() + " " + bar();
+  }
+}
+```
+
+Or a `static` method:
+
+```
+@AutoMatter
+interface Foobar {
+  String foo();
+  int bar();
+
+  @AutoMatter.ToString
+  static String toString(Foobar v) {
+    return v.foo() + " " + v.bar();
+  }
+}
+```
+
+Note that in the case of a default method, the method name cannot be `toString` as default methods are not
+allowed to override methods from `java.lang.Object`.
+
 ### Known Issues
 
 There's an issue with maven-compiler-plugin 3.x and annotation processors that causes

--- a/annotation/src/main/java/io/norberg/automatter/AutoMatter.java
+++ b/annotation/src/main/java/io/norberg/automatter/AutoMatter.java
@@ -18,4 +18,9 @@ public @interface AutoMatter {
 
     String value() default "";
   }
+
+  @Target(METHOD)
+  @Retention(RUNTIME)
+  @interface ToString {
+  }
 }

--- a/example/src/main/java/io/norberg/automatter/example/CustomToStringFoobarDefault.java
+++ b/example/src/main/java/io/norberg/automatter/example/CustomToStringFoobarDefault.java
@@ -1,0 +1,14 @@
+package io.norberg.automatter.example;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface CustomToStringFoobarDefault {
+  String foo();
+  int bar();
+
+  @AutoMatter.ToString
+  default String overrideToString() {
+    return foo() + " " + bar();
+  }
+}

--- a/example/src/main/java/io/norberg/automatter/example/CustomToStringFoobarStatic.java
+++ b/example/src/main/java/io/norberg/automatter/example/CustomToStringFoobarStatic.java
@@ -1,0 +1,14 @@
+package io.norberg.automatter.example;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface CustomToStringFoobarStatic {
+  String foo();
+  int bar();
+
+  @AutoMatter.ToString
+  static String toString(CustomToStringFoobarStatic v) {
+    return v.foo() + " " + v.bar();
+  }
+}

--- a/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
+++ b/processor/src/test/java/io/norberg/automatter/AutoMatterProcessorTest.java
@@ -383,6 +383,26 @@ public class AutoMatterProcessorTest {
             expectedSource("expected/deferred-processing/BarBuilder.java"));
   }
 
+  @Test
+  public void testCustomToStringDefault() {
+    final JavaFileObject source = JavaFileObjects.forResource("good/CustomToStringDefault.java");
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(new AutoMatterProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(expectedSource("expected/CustomToStringDefaultBuilder.java"));
+  }
+
+  @Test
+  public void testCustomToStringStatic() {
+    final JavaFileObject source = JavaFileObjects.forResource("good/CustomToStringStatic.java");
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(new AutoMatterProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(expectedSource("expected/CustomToStringStaticBuilder.java"));
+  }
+
   private boolean isJava8() {
     try {
       Class.forName("java.util.Optional");

--- a/processor/src/test/resources/expected/CustomToStringDefaultBuilder.java
+++ b/processor/src/test/resources/expected/CustomToStringDefaultBuilder.java
@@ -1,0 +1,93 @@
+package foo;
+
+import io.norberg.automatter.AutoMatter;
+${GENERATED_IMPORT}
+
+${GENERATED_ANNOTATION}
+public final class CustomToStringDefaultBuilder {
+  private String foo;
+
+  public CustomToStringDefaultBuilder() {
+  }
+
+  private CustomToStringDefaultBuilder(CustomToStringDefault v) {
+    this.foo = v.foo();
+  }
+
+  private CustomToStringDefaultBuilder(CustomToStringDefaultBuilder v) {
+    this.foo = v.foo;
+  }
+
+  public String foo() {
+    return foo;
+  }
+
+  public CustomToStringDefaultBuilder foo(String foo) {
+    if (foo == null) {
+      throw new NullPointerException("foo");
+    }
+    this.foo = foo;
+    return this;
+  }
+
+  public CustomToStringDefault build() {
+    return new Value(foo);
+  }
+
+  public static CustomToStringDefaultBuilder from(CustomToStringDefault v) {
+    return new CustomToStringDefaultBuilder(v);
+  }
+
+  public static CustomToStringDefaultBuilder from(CustomToStringDefaultBuilder v) {
+    return new CustomToStringDefaultBuilder(v);
+  }
+
+  private static final class Value implements CustomToStringDefault {
+    private final String foo;
+
+    private Value(@AutoMatter.Field("foo") String foo) {
+      if (foo == null) {
+        throw new NullPointerException("foo");
+      }
+      this.foo = foo;
+    }
+
+    @AutoMatter.Field
+    @Override
+    public String foo() {
+      return foo;
+    }
+
+    public CustomToStringDefaultBuilder builder() {
+      return new CustomToStringDefaultBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CustomToStringDefault)) {
+        return false;
+      }
+      final CustomToStringDefault that = (CustomToStringDefault) o;
+      if (foo != null ? !foo.equals(that.foo()) : that.foo() != null) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      long temp;
+      result = 31 * result + (this.foo != null ? this.foo.hashCode() : 0);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return overrideToString();
+    }
+  }
+}

--- a/processor/src/test/resources/expected/CustomToStringStaticBuilder.java
+++ b/processor/src/test/resources/expected/CustomToStringStaticBuilder.java
@@ -1,0 +1,93 @@
+package foo;
+
+import io.norberg.automatter.AutoMatter;
+${GENERATED_IMPORT}
+
+${GENERATED_ANNOTATION}
+public final class CustomToStringStaticBuilder {
+  private String foo;
+
+  public CustomToStringStaticBuilder() {
+  }
+
+  private CustomToStringStaticBuilder(CustomToStringStatic v) {
+    this.foo = v.foo();
+  }
+
+  private CustomToStringStaticBuilder(CustomToStringStaticBuilder v) {
+    this.foo = v.foo;
+  }
+
+  public String foo() {
+    return foo;
+  }
+
+  public CustomToStringStaticBuilder foo(String foo) {
+    if (foo == null) {
+      throw new NullPointerException("foo");
+    }
+    this.foo = foo;
+    return this;
+  }
+
+  public CustomToStringStatic build() {
+    return new Value(foo);
+  }
+
+  public static CustomToStringStaticBuilder from(CustomToStringStatic v) {
+    return new CustomToStringStaticBuilder(v);
+  }
+
+  public static CustomToStringStaticBuilder from(CustomToStringStaticBuilder v) {
+    return new CustomToStringStaticBuilder(v);
+  }
+
+  private static final class Value implements CustomToStringStatic {
+    private final String foo;
+
+    private Value(@AutoMatter.Field("foo") String foo) {
+      if (foo == null) {
+        throw new NullPointerException("foo");
+      }
+      this.foo = foo;
+    }
+
+    @AutoMatter.Field
+    @Override
+    public String foo() {
+      return foo;
+    }
+
+    public CustomToStringStaticBuilder builder() {
+      return new CustomToStringStaticBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CustomToStringStatic)) {
+        return false;
+      }
+      final CustomToStringStatic that = (CustomToStringStatic) o;
+      if (foo != null ? !foo.equals(that.foo()) : that.foo() != null) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      long temp;
+      result = 31 * result + (this.foo != null ? this.foo.hashCode() : 0);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return CustomToStringStatic.toString(this);
+    }
+  }
+}

--- a/processor/src/test/resources/good/CustomToStringDefault.java
+++ b/processor/src/test/resources/good/CustomToStringDefault.java
@@ -1,0 +1,21 @@
+package foo;
+
+import java.util.Optional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface CustomToStringDefault {
+  String foo();
+
+  @AutoMatter.ToString
+  default String overrideToString() {
+    return foo();
+  }
+}

--- a/processor/src/test/resources/good/CustomToStringStatic.java
+++ b/processor/src/test/resources/good/CustomToStringStatic.java
@@ -1,0 +1,21 @@
+package foo;
+
+import java.util.Optional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface CustomToStringStatic {
+  String foo();
+
+  @AutoMatter.ToString
+  static String toString(CustomToStringStatic v) {
+    return v.foo();
+  }
+}


### PR DESCRIPTION
Usage with a `default` method:

```java
@AutoMatter
interface Foobar {
  String foo();
  int bar();

  @AutoMatter.ToString
  default String overrideToString() {
    return foo() + " " + bar();
  }
}
```

or with a `static` method:

```java
@AutoMatter
interface Foobar {
  String foo();
  int bar();

  @AutoMatter.ToString
  static String toString(Foobar v) {
    return v.foo() + " " + v.bar();
  }
}
```