### PR TITLE
Suppress varargs warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,8 @@
           <compilerArgs>
             <compilerArg>-Xlint:all</compilerArg>
           </compilerArgs>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
       <plugin>

--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -539,6 +539,13 @@ public final class AutoMatterProcessor extends AbstractProcessor {
     setter
         .addAnnotation(safeVarargsAnnotation)
         .addModifiers(FINAL); // Only because SafeVarargs can be applied to final methods.
+
+    // Suppress the following warnings for varargs setters:
+    // "Redundant java.lang.SafeVarargs annotation. Varargs element type X is reifiable."
+    // "Varargs method could cause heap pollution from non-reifiable varargs parameter x"
+    AnnotationSpec varargWarningSuppression =
+        AnnotationSpec.builder(SuppressWarnings.class).addMember("value", "$S", "varargs").build();
+    setter.addAnnotation(varargWarningSuppression);
   }
 
   private MethodSpec collectionAdder(final Descriptor d, final ExecutableElement field) {

--- a/processor/src/test/resources/expected/CollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/CollectionFieldsBuilder.java
@@ -115,6 +115,7 @@ public final class CollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final CollectionFieldsBuilder strings(String... strings) {
     if (strings == null) {
       throw new NullPointerException("strings");
@@ -474,6 +475,7 @@ public final class CollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final CollectionFieldsBuilder numbers(Long... numbers) {
     if (numbers == null) {
       throw new NullPointerException("numbers");
@@ -542,6 +544,7 @@ public final class CollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final CollectionFieldsBuilder sortedNumbers(Long... sortedNumbers) {
     if (sortedNumbers == null) {
       throw new NullPointerException("sortedNumbers");
@@ -610,6 +613,7 @@ public final class CollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final CollectionFieldsBuilder navigableNumbers(Long... navigableNumbers) {
     if (navigableNumbers == null) {
       throw new NullPointerException("navigableNumbers");

--- a/processor/src/test/resources/expected/CollectionInterfaceFieldBuilder.java
+++ b/processor/src/test/resources/expected/CollectionInterfaceFieldBuilder.java
@@ -70,6 +70,7 @@ public final class CollectionInterfaceFieldBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final CollectionInterfaceFieldBuilder strings(String... strings) {
     if (strings == null) {
       throw new NullPointerException("strings");

--- a/processor/src/test/resources/expected/GenericCollectionBuilder.java
+++ b/processor/src/test/resources/expected/GenericCollectionBuilder.java
@@ -82,6 +82,7 @@ public final class GenericCollectionBuilder<T, K, V> {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final GenericCollectionBuilder<T, K, V> foos(T... foos) {
     if (foos == null) {
       throw new NullPointerException("foos");

--- a/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
+++ b/processor/src/test/resources/expected/NullableCollectionFieldsBuilder.java
@@ -80,6 +80,7 @@ public final class NullableCollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final NullableCollectionFieldsBuilder strings(String... strings) {
     if (strings == null) {
       this.strings = null;
@@ -199,6 +200,7 @@ public final class NullableCollectionFieldsBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final NullableCollectionFieldsBuilder numbers(Long... numbers) {
     if (numbers == null) {
       this.numbers = null;

--- a/processor/src/test/resources/expected/inheritance/ConcreteExtensionOfGenericParentBuilder.java
+++ b/processor/src/test/resources/expected/inheritance/ConcreteExtensionOfGenericParentBuilder.java
@@ -75,6 +75,7 @@ public final class ConcreteExtensionOfGenericParentBuilder {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final ConcreteExtensionOfGenericParentBuilder foos(Integer... foos) {
     if (foos == null) {
       throw new NullPointerException("foos");

--- a/processor/src/test/resources/expected/inheritance/GenericCollectionParentBuilder.java
+++ b/processor/src/test/resources/expected/inheritance/GenericCollectionParentBuilder.java
@@ -75,6 +75,7 @@ public final class GenericCollectionParentBuilder<T> {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final GenericCollectionParentBuilder<T> foos(T... foos) {
     if (foos == null) {
       throw new NullPointerException("foos");


### PR DESCRIPTION
Combining and always emitting `@SafeVarargs` and `@SuppressWarnings("varargs")` for varargs setters seems to be the most straightforward way of silencing warnings both when compiling the setter and when compiling the call-sites.

Also see `j.u.List.of(E...)` and `j.u.Arrays.asList(T...)`.