### PR TITLE
Serialize explicit types

### DIFF
--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
@@ -52,8 +52,11 @@ class AutoMatterAnnotationIntrospector extends NopAnnotationIntrospector {
   public JavaType refineSerializationType(
       final MapperConfig<?> config, final Annotated a, final JavaType baseType)
       throws JsonMappingException {
-    if (baseType.isInterface() && a.hasAnnotation(AutoMatter.class)) {
-      return typeCache.resolveValueType(baseType.getRawClass());
+    final Class<?> rawClass = baseType.getRawClass();
+
+    // Refine only if baseType is explicitly annotated with @AutoMatter
+    if (rawClass.isAnnotationPresent(AutoMatter.class)) {
+      return typeCache.resolveValueType(rawClass);
     }
     return super.refineSerializationType(config, a, baseType);
   }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
@@ -1,5 +1,8 @@
 package io.norberg.automatter.jackson;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
@@ -11,6 +14,11 @@ import io.norberg.automatter.AutoMatter;
 class AutoMatterAnnotationIntrospector extends NopAnnotationIntrospector {
 
   private static final long serialVersionUID = 1L;
+  private final ValueTypeCache typeCache;
+
+  AutoMatterAnnotationIntrospector(final ValueTypeCache typeCache) {
+    this.typeCache = typeCache;
+  }
 
   @Override
   public String findImplicitPropertyName(final AnnotatedMember member) {
@@ -38,5 +46,15 @@ class AutoMatterAnnotationIntrospector extends NopAnnotationIntrospector {
     }
     final AutoMatter.Field field = ctor.getParameter(0).getAnnotation(AutoMatter.Field.class);
     return field != null;
+  }
+
+  @Override
+  public JavaType refineSerializationType(
+      final MapperConfig<?> config, final Annotated a, final JavaType baseType)
+      throws JsonMappingException {
+    if (baseType.isInterface() && a.hasAnnotation(AutoMatter.class)) {
+      return typeCache.resolveValueType(baseType.getRawClass());
+    }
+    return super.refineSerializationType(config, a, baseType);
   }
 }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterModule.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterModule.java
@@ -9,7 +9,8 @@ public class AutoMatterModule extends SimpleModule {
   @Override
   public void setupModule(final SetupContext context) {
     super.setupModule(context);
-    context.addAbstractTypeResolver(new AutoMatterResolver());
-    context.appendAnnotationIntrospector(new AutoMatterAnnotationIntrospector());
+    final ValueTypeCache typeCache = new ValueTypeCache(context.getTypeFactory());
+    context.addAbstractTypeResolver(new AutoMatterResolver(typeCache));
+    context.appendAnnotationIntrospector(new AutoMatterAnnotationIntrospector(typeCache));
   }
 }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import io.norberg.automatter.AutoMatter;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 class AutoMatterResolver extends AbstractTypeResolver {
 
-  private static final String VALUE_SUFFIX = "Builder$Value";
+  private final ValueTypeCache typeCache;
 
-  private final ConcurrentMap<Class<?>, JavaType> types = new ConcurrentHashMap<>();
+  AutoMatterResolver(final ValueTypeCache typeCache) {
+    this.typeCache = typeCache;
+  }
 
   @SuppressWarnings("deprecation")
   public JavaType resolveAbstractType(DeserializationConfig config, JavaType type) {
@@ -31,26 +31,7 @@ class AutoMatterResolver extends AbstractTypeResolver {
       return null;
     }
 
-    // Return the cached type, if present.
-    final JavaType cached = types.get(rawClass);
-    if (cached != null) {
-      return cached;
-    }
-
-    // Look up and instantiate the value class
-    final String packageName = rawClass.getPackage().getName();
-    final String name = rawClass.getSimpleName();
-    final String valueName = packageName + '.' + name + VALUE_SUFFIX;
-    final Class<?> cls;
-    try {
-      cls = Class.forName(valueName);
-    } catch (ClassNotFoundException e) {
-      throw new IllegalArgumentException("No builder found for @AutoMatter type: " + name, e);
-    }
-    final JavaType materialized = config.getTypeFactory().constructType(cls);
-
-    // Cache the materialized type before returning
-    final JavaType existing = types.putIfAbsent(rawClass, materialized);
-    return (existing != null) ? existing : materialized;
+    // Resolve from cache.
+    return typeCache.resolveValueType(rawClass);
   }
 }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
@@ -1,0 +1,43 @@
+package io.norberg.automatter.jackson;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+class ValueTypeCache {
+
+  private static final String VALUE_SUFFIX = "Builder$Value";
+
+  private final ConcurrentMap<Class<?>, JavaType> types = new ConcurrentHashMap<>();
+
+  private final TypeFactory typeFactory;
+
+  public ValueTypeCache(final TypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+  }
+
+  JavaType resolveValueType(final Class<?> rawClass) {
+    // Return the cached type, if present.
+    final JavaType cached = types.get(rawClass);
+    if (cached != null) {
+      return cached;
+    }
+
+    // Look up and instantiate the value class
+    final String packageName = rawClass.getPackage().getName();
+    final String name = rawClass.getSimpleName();
+    final String valueName = packageName + '.' + name + VALUE_SUFFIX;
+    final Class<?> cls;
+    try {
+      cls = Class.forName(valueName);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("No builder found for type: " + name, e);
+    }
+    final JavaType materialized = typeFactory.constructType(cls);
+
+    // Cache the materialized type before returning
+    final JavaType existing = types.putIfAbsent(rawClass, materialized);
+    return (existing != null) ? existing : materialized;
+  }
+}

--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -38,6 +38,13 @@ public class AutoMatterModuleTest {
   }
 
   @Test
+  public void explicitRootType() throws IOException {
+    final String json = mapper.writerFor(Foo.class).writeValueAsString(FOO);
+    final Foo parsed = mapper.readValue(json, Foo.class);
+    assertThat(parsed, is(FOO));
+  }
+
+  @Test
   public void testInner() throws IOException {
     final String json = mapper.writeValueAsString(BAR);
     final WithInner.Bar parsed = mapper.readValue(json, WithInner.Bar.class);


### PR DESCRIPTION
- This PR fixes a problem where serialization doesn't work if you provide an AutoMatter interface as the explicit root type (see added test case). 
- This is achieved by refining AutoMatter annotated interface types to the actual value types that already work well with serialization.
- Since resolving value types with caching is now done in two places, this functionality is broken out into it's own class.