### PR TITLE
Exclude com.h2database:h2

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -52,6 +52,12 @@
     <dependency>
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.h2database</groupId>
+          <artifactId>h2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!--test deps-->


### PR DESCRIPTION
Not exactly sure how this got pulled in by modeshape-common, but it seems weird to have it anyway.