### PR TITLE
Fix Jackson generic type deserialization

### DIFF
--- a/jackson-it.sh
+++ b/jackson-it.sh
@@ -6,7 +6,7 @@ function lookup_jackson_versions0() {
   jq -r '[.response.docs | .[].v |
          {p: split("."), v:.} |
          {major:.p[0] | tonumber, minor: .p[1] | tonumber, v:.v} |
-         select(.major >= 2 and .minor >= 4)] |
+         select(.major >= 2 and .minor >= 7)] |
          sort_by([.major, .minor, .v]) |
          .[].v' |
   grep -v rc |       # omit rc versions

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterAnnotationIntrospector.java
@@ -56,7 +56,7 @@ class AutoMatterAnnotationIntrospector extends NopAnnotationIntrospector {
 
     // Refine only if baseType is an interface explicitly annotated with @AutoMatter
     if (cls.isInterface() && cls.isAnnotationPresent(AutoMatter.class)) {
-      return typeCache.resolveValueType(cls);
+      return typeCache.resolveValueType(baseType);
     }
     return super.refineSerializationType(config, a, baseType);
   }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/AutoMatterResolver.java
@@ -16,26 +16,26 @@ class AutoMatterResolver extends AbstractTypeResolver {
 
   @SuppressWarnings("deprecation")
   public JavaType resolveAbstractType(DeserializationConfig config, JavaType type) {
-    return resolveAbstractType0(config, type.getRawClass());
+    return resolveAbstractType0(config, type);
   }
 
   public JavaType resolveAbstractType(DeserializationConfig config, BeanDescription typeDesc) {
-    return resolveAbstractType0(config, typeDesc.getBeanClass());
+    return resolveAbstractType0(config, typeDesc.getType());
   }
 
-  private JavaType resolveAbstractType0(final DeserializationConfig config, final Class<?> cls) {
-    if (!cls.isInterface()) {
+  private JavaType resolveAbstractType0(final DeserializationConfig config, JavaType type) {
+    if (!type.isInterface()) {
       // Only resolve interface style @AutoMatter types.
       return null;
     }
 
-    final AutoMatter annotation = cls.getAnnotation(AutoMatter.class);
+    final AutoMatter annotation = type.getRawClass().getAnnotation(AutoMatter.class);
     if (annotation == null) {
       // This was not an @AutoMatter type.
       return null;
     }
 
     // Resolve from cache.
-    return typeCache.resolveValueType(cls);
+    return typeCache.resolveValueType(type);
   }
 }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
@@ -37,7 +37,9 @@ class ValueTypeCache {
 
     final JavaType materialized;
     if (type.hasGenericTypes()) {
-      materialized = typeFactory.constructParametricType(cls, type.getBindings());
+      materialized =
+          typeFactory.constructParametricType(
+              cls, type.getBindings().getTypeParameters().toArray(new JavaType[0]));
     } else {
       materialized = typeFactory.constructType(cls);
     }

--- a/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
+++ b/jackson/src/main/java/io/norberg/automatter/jackson/ValueTypeCache.java
@@ -9,7 +9,7 @@ class ValueTypeCache {
 
   private static final String VALUE_SUFFIX = "Builder$Value";
 
-  private final ConcurrentMap<Class<?>, JavaType> types = new ConcurrentHashMap<>();
+  private final ConcurrentMap<JavaType, JavaType> types = new ConcurrentHashMap<>();
 
   private final TypeFactory typeFactory;
 
@@ -17,16 +17,16 @@ class ValueTypeCache {
     this.typeFactory = typeFactory;
   }
 
-  JavaType resolveValueType(final Class<?> rawClass) {
+  JavaType resolveValueType(final JavaType type) {
     // Return the cached type, if present.
-    final JavaType cached = types.get(rawClass);
+    final JavaType cached = types.get(type);
     if (cached != null) {
       return cached;
     }
 
     // Look up and instantiate the value class
-    final String packageName = rawClass.getPackage().getName();
-    final String name = rawClass.getSimpleName();
+    final String packageName = type.getRawClass().getPackage().getName();
+    final String name = type.getRawClass().getSimpleName();
     final String valueName = packageName + '.' + name + VALUE_SUFFIX;
     final Class<?> cls;
     try {
@@ -34,10 +34,16 @@ class ValueTypeCache {
     } catch (ClassNotFoundException e) {
       throw new IllegalArgumentException("No builder found for type: " + name, e);
     }
-    final JavaType materialized = typeFactory.constructType(cls);
+
+    final JavaType materialized;
+    if (type.hasGenericTypes()) {
+      materialized = typeFactory.constructParametricType(cls, type.getBindings());
+    } else {
+      materialized = typeFactory.constructType(cls);
+    }
 
     // Cache the materialized type before returning
-    final JavaType existing = types.putIfAbsent(rawClass, materialized);
+    final JavaType existing = types.putIfAbsent(type, materialized);
     return (existing != null) ? existing : materialized;
   }
 }

--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -4,7 +4,9 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategy.CAMEL_CASE_T
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -16,6 +18,7 @@ import org.junit.Test;
 public class AutoMatterModuleTest {
 
   static final Foo FOO = new FooBuilder().a(17).b("foobar").aCamelCaseField(true).build();
+  static final GenericFoo GENERIC_FOO = new GenericFooBuilder<Foo>().a(FOO).build();
 
   static final WithInner.Bar BAR = new BarBuilder().a(17).b("foobar").aCamelCaseField(true).build();
 
@@ -112,5 +115,12 @@ public class AutoMatterModuleTest {
     assertThat(parsed.list().isEmpty(), is(true));
     assertThat(parsed.set().isEmpty(), is(true));
     assertThat(parsed.map().isEmpty(), is(true));
+  }
+
+  @Test
+  public void testGeneric() throws JsonProcessingException {
+    final String json = mapper.writeValueAsString(GENERIC_FOO);
+    final GenericFoo<Foo> parsed = mapper.readValue(json, new TypeReference<GenericFoo<Foo>>() {});
+    assertThat(parsed, is(GENERIC_FOO));
   }
 }

--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -132,9 +132,5 @@ public class AutoMatterModuleTest {
     final GenericFoo<GenericFoo<Foo>> parsed =
         mapper.readValue(json, new TypeReference<GenericFoo<GenericFoo<Foo>>>() {});
     assertThat(parsed, is(NESTED_GENERIC_FOO));
-
-    final GenericFoo<GenericFoo<Foo>> parsed2 =
-        mapper.readValue(json, new TypeReference<GenericFoo<GenericFoo<Foo>>>() {});
-    assertThat(parsed2, is(NESTED_GENERIC_FOO));
   }
 }

--- a/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/AutoMatterModuleTest.java
@@ -19,6 +19,8 @@ public class AutoMatterModuleTest {
 
   static final Foo FOO = new FooBuilder().a(17).b("foobar").aCamelCaseField(true).build();
   static final GenericFoo GENERIC_FOO = new GenericFooBuilder<Foo>().a(FOO).build();
+  static final GenericFoo NESTED_GENERIC_FOO =
+      new GenericFooBuilder<GenericFoo<Foo>>().a(GENERIC_FOO).build();
 
   static final WithInner.Bar BAR = new BarBuilder().a(17).b("foobar").aCamelCaseField(true).build();
 
@@ -122,5 +124,17 @@ public class AutoMatterModuleTest {
     final String json = mapper.writeValueAsString(GENERIC_FOO);
     final GenericFoo<Foo> parsed = mapper.readValue(json, new TypeReference<GenericFoo<Foo>>() {});
     assertThat(parsed, is(GENERIC_FOO));
+  }
+
+  @Test
+  public void testNestedGeneric() throws JsonProcessingException {
+    final String json = mapper.writeValueAsString(NESTED_GENERIC_FOO);
+    final GenericFoo<GenericFoo<Foo>> parsed =
+        mapper.readValue(json, new TypeReference<GenericFoo<GenericFoo<Foo>>>() {});
+    assertThat(parsed, is(NESTED_GENERIC_FOO));
+
+    final GenericFoo<GenericFoo<Foo>> parsed2 =
+        mapper.readValue(json, new TypeReference<GenericFoo<GenericFoo<Foo>>>() {});
+    assertThat(parsed2, is(NESTED_GENERIC_FOO));
   }
 }

--- a/jackson/src/test/java/io/norberg/automatter/jackson/GenericFoo.java
+++ b/jackson/src/test/java/io/norberg/automatter/jackson/GenericFoo.java
@@ -1,0 +1,8 @@
+package io.norberg.automatter.jackson;
+
+import io.norberg.automatter.AutoMatter;
+
+@AutoMatter
+public interface GenericFoo<T> {
+  T a();
+}


### PR DESCRIPTION
Note that this requires using jackson 2.7+ when deserializing generic types.