### PR TITLE
Fix for auto-matter interface extending an interface nested inside another class

### DIFF
--- a/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/AutoMatterProcessor.java
@@ -1367,7 +1367,14 @@ public final class AutoMatterProcessor extends AbstractProcessor {
   }
 
   private ClassName rawValueType(final Descriptor d) {
-    return ClassName.get(d.packageName(), d.valueTypeName());
+    if (d.valueTypeName().contains(".")) {
+      String[] simpleName = d.valueTypeName().split("\\.");
+      String[] remainderSimpleName =
+          Arrays.copyOfRange(simpleName, 1, simpleName.length, String[].class);
+      return ClassName.get(d.packageName(), simpleName[0], remainderSimpleName);
+    } else {
+      return ClassName.get(d.packageName(), d.valueTypeName());
+    }
   }
 
   private TypeName unboundedValueType(final Descriptor d) {

--- a/test/src/test/java/io/norberg/automatter/other/InheritenceR1.java
+++ b/test/src/test/java/io/norberg/automatter/other/InheritenceR1.java
@@ -1,0 +1,11 @@
+package io.norberg.automatter.other;
+
+import io.norberg.automatter.AutoMatter;
+
+public interface InheritenceR1 {
+
+  @AutoMatter
+  interface InheritenceR2 {
+    String callR2();
+  }
+}

--- a/test/src/test/java/io/norberg/automatter/test/InheritanceTest.java
+++ b/test/src/test/java/io/norberg/automatter/test/InheritanceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.norberg.automatter.AutoMatter;
+import io.norberg.automatter.other.InheritenceR1;
 import java.util.List;
 import org.junit.Test;
 
@@ -34,6 +35,11 @@ public class InheritanceTest {
   @AutoMatter
   interface InheritanceCorge extends InheritanceQuux<Integer> {
     int corge();
+  }
+
+  @AutoMatter
+  interface InheritenceR extends InheritenceR1.InheritenceR2 {
+    String callR();
   }
 
   @Test


### PR DESCRIPTION
Daniel thank you for all of your work on auto-matter. My employer uses it extensively with great success. We are trying to upgrade from version 0.15.3 to 0.26.0 and have encountered a regression where an auto-matter interface that extends another auto-matter interface that is nested inside another class generates code that fails to compile. 

I have identified a fix that seems to solve the problem, and have added a test for this situation. Please have a look, you may want to fix this issue some other way given your much deeper knowledge of the codebase.

Thanks again for all of your work and effort.