### PR TITLE
Preserve record components order

### DIFF
--- a/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
@@ -224,15 +224,28 @@ class Descriptor {
 
   private void enumerateMethods(
       final TypeElement element, final Map<String, ExecutableElement> methods) {
-    for (final TypeMirror interfaceType : element.getInterfaces()) {
-      final TypeElement interfaceElement = (TypeElement) ((DeclaredType) interfaceType).asElement();
-      enumerateMethods(interfaceElement, methods);
+    if (isRecord) {
+      enumerateEnclosedMethods(element, methods);
+      enumerateInheritedMethods(element, methods);
+    } else {
+      enumerateInheritedMethods(element, methods);
+      enumerateEnclosedMethods(element, methods);
     }
+  }
+
+  private static void enumerateEnclosedMethods(TypeElement element, Map<String, ExecutableElement> methods) {
     for (final Element member : element.getEnclosedElements()) {
       if (member.getKind() != ElementKind.METHOD) {
         continue;
       }
       methods.put(member.getSimpleName().toString(), (ExecutableElement) member);
+    }
+  }
+
+  private void enumerateInheritedMethods(TypeElement element, Map<String, ExecutableElement> methods) {
+    for (final TypeMirror interfaceType : element.getInterfaces()) {
+      final TypeElement interfaceElement = (TypeElement) ((DeclaredType) interfaceType).asElement();
+      enumerateMethods(interfaceElement, methods);
     }
   }
 

--- a/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
+++ b/processor/src/main/java/io/norberg/automatter/processor/Descriptor.java
@@ -233,7 +233,8 @@ class Descriptor {
     }
   }
 
-  private static void enumerateEnclosedMethods(TypeElement element, Map<String, ExecutableElement> methods) {
+  private static void enumerateEnclosedMethods(
+      TypeElement element, Map<String, ExecutableElement> methods) {
     for (final Element member : element.getEnclosedElements()) {
       if (member.getKind() != ElementKind.METHOD) {
         continue;
@@ -242,7 +243,8 @@ class Descriptor {
     }
   }
 
-  private void enumerateInheritedMethods(TypeElement element, Map<String, ExecutableElement> methods) {
+  private void enumerateInheritedMethods(
+      TypeElement element, Map<String, ExecutableElement> methods) {
     for (final TypeMirror interfaceType : element.getInterfaces()) {
       final TypeElement interfaceElement = (TypeElement) ((DeclaredType) interfaceType).asElement();
       enumerateMethods(interfaceElement, methods);

--- a/record-test/src/test/resources/expected/BazRecordBuilder.java
+++ b/record-test/src/test/resources/expected/BazRecordBuilder.java
@@ -6,21 +6,69 @@ import javax.annotation.processing.Generated;
 @Generated("io.norberg.automatter.processor.AutoMatterProcessor")
 @AutoMatter.Generated
 public final class BazRecordBuilder {
+  private String baz1;
+
   private int a;
 
   private String b;
+
+  private boolean c;
+
+  private long d;
+
+  private String baz2;
 
   public BazRecordBuilder() {
   }
 
   private BazRecordBuilder(BazRecordContainer.BazRecord v) {
+    this.baz1 = v.baz1();
+    this.a = v.a();
+    this.b = v.b();
+    this.c = v.c();
+    this.d = v.d();
+    this.baz2 = v.baz2();
+  }
+
+  private BazRecordBuilder(BazRecordContainer.Foobar1 v) {
     this.a = v.a();
     this.b = v.b();
   }
 
+  private BazRecordBuilder(BazRecordContainer.Foobar2 v) {
+    this.c = v.c();
+    this.d = v.d();
+  }
+
   private BazRecordBuilder(BazRecordBuilder v) {
+    this.baz1 = v.baz1();
     this.a = v.a();
     this.b = v.b();
+    this.c = v.c();
+    this.d = v.d();
+    this.baz2 = v.baz2();
+  }
+
+  private BazRecordBuilder(Foobar1Builder v) {
+    this.a = v.a();
+    this.b = v.b();
+  }
+
+  private BazRecordBuilder(Foobar2Builder v) {
+    this.c = v.c();
+    this.d = v.d();
+  }
+
+  public String baz1() {
+    return baz1;
+  }
+
+  public BazRecordBuilder baz1(String baz1) {
+    if (baz1 == null) {
+      throw new NullPointerException("baz1");
+    }
+    this.baz1 = baz1;
+    return this;
   }
 
   public int a() {
@@ -44,22 +92,74 @@ public final class BazRecordBuilder {
     return this;
   }
 
+  public boolean c() {
+    return c;
+  }
+
+  public BazRecordBuilder c(boolean c) {
+    this.c = c;
+    return this;
+  }
+
+  public long d() {
+    return d;
+  }
+
+  public BazRecordBuilder d(long d) {
+    this.d = d;
+    return this;
+  }
+
+  public String baz2() {
+    return baz2;
+  }
+
+  public BazRecordBuilder baz2(String baz2) {
+    if (baz2 == null) {
+      throw new NullPointerException("baz2");
+    }
+    this.baz2 = baz2;
+    return this;
+  }
+
   public static BazRecordBuilder builder() {
     return new BazRecordBuilder();
   }
 
   public BazRecordContainer.BazRecord build() {
+    if (baz1 == null) {
+      throw new NullPointerException("baz1");
+    }
     if (b == null) {
       throw new NullPointerException("b");
     }
-    return new BazRecordContainer.BazRecord(a, b);
+    if (baz2 == null) {
+      throw new NullPointerException("baz2");
+    }
+    return new BazRecordContainer.BazRecord(baz1, a, b, c, d, baz2);
   }
 
   public static BazRecordBuilder from(BazRecordContainer.BazRecord v) {
     return new BazRecordBuilder(v);
   }
 
+  public static BazRecordBuilder from(BazRecordContainer.Foobar1 v) {
+    return new BazRecordBuilder(v);
+  }
+
+  public static BazRecordBuilder from(BazRecordContainer.Foobar2 v) {
+    return new BazRecordBuilder(v);
+  }
+
   public static BazRecordBuilder from(BazRecordBuilder v) {
+    return new BazRecordBuilder(v);
+  }
+
+  public static BazRecordBuilder from(Foobar1Builder v) {
+    return new BazRecordBuilder(v);
+  }
+
+  public static BazRecordBuilder from(Foobar2Builder v) {
     return new BazRecordBuilder(v);
   }
 }

--- a/record-test/src/test/resources/good/BazRecordContainer.java
+++ b/record-test/src/test/resources/good/BazRecordContainer.java
@@ -3,7 +3,34 @@ package foo;
 import io.norberg.automatter.AutoMatter;
 
 public class BazRecordContainer {
-  @AutoMatter
-  public record BazRecord(int a, String b) {}
-}
 
+  @AutoMatter
+  public record BazRecord(String baz1, int a, String b, boolean c, long d, String baz2)
+      implements Foobar1, Foobar2 {
+    public int baz() {
+      return 1;
+    }
+  }
+
+  @AutoMatter
+  public interface Foobar1 {
+    int a();
+
+    String b();
+
+    static int foobar1() {
+      return 1;
+    }
+  }
+
+  @AutoMatter
+  public interface Foobar2 {
+    boolean c();
+
+    long d();
+
+    static int foobar2() {
+      return 2;
+    }
+  }
+}


### PR DESCRIPTION
Since the `Value` class is not generated for record, it is important to preserve the component order, otherwise wrong code is generated when constructing the record.

As an example:

```java
public class BazRecordContainer {

  @AutoMatter
  public record BazRecord(String baz1, int a, String b, String baz2)
      implements Foobar1 {}

  @AutoMatter
  public interface Foobar1 {
    int a();

    String b();
  }
}
```

The generated builder does `return new BazRecordContainer.BazRecord(a, b, baz1, baz2)`, which is obviously wrong.

This PR fixes it by swapping the order when enumerating methods, if it is a record.